### PR TITLE
fix: aws-lc-sys を 0.42.0 に更新 (GHSA-394x-vwmw-crm3)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -212,14 +212,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `aws-lc-rs` を v1.16.1 → v1.17.1 に更新し、間接依存の `aws-lc-sys` を v0.38.0 → v0.42.0 へ更新
- Dependabot アラート [#36](https://github.com/omnius-labs/axus/security/dependabot/36) への対応
- 脆弱性: X.509 Name Constraints Bypass via Wildcard/Unicode CN（GHSA-394x-vwmw-crm3、深刻度: High）

## Test plan

- [x] `cargo check` でビルド成功を確認済み