### PR TITLE
fix: CI ワークフローの高速化

### DIFF
--- a/.github/workflows/test-daemon-all.yml
+++ b/.github/workflows/test-daemon-all.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
+          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -56,7 +57,8 @@ jobs:
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          shared-key: "ubuntu-latest-lint-all"
+          shared-key: "ubuntu-latest-all"
+          cache-on-failure: "true"
           cache-workspace-crates: "true"
           workspaces: |
             daemon -> target
@@ -65,7 +67,6 @@ jobs:
         run: cargo make lint
 
   test:
-    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -92,17 +93,22 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
+          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          shared-key: "${{ matrix.os }}-test-all"
+          shared-key: "${{ matrix.os }}-all"
+          cache-on-failure: "true"
           cache-workspace-crates: "true"
           workspaces: |
             daemon -> target
 
       - name: Test
-        run: cargo test --features "stable-test"
+        run: cargo nextest run --features "stable-test"

--- a/.github/workflows/test-daemon-all.yml
+++ b/.github/workflows/test-daemon-all.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
-          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -93,7 +92,6 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
-          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-daemon-slim.yml
+++ b/.github/workflows/test-daemon-slim.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
-          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -87,7 +86,6 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
-          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-daemon-slim.yml
+++ b/.github/workflows/test-daemon-slim.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
+          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -54,7 +55,8 @@ jobs:
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          shared-key: "ubuntu-latest-lint-slim"
+          shared-key: "ubuntu-latest-slim"
+          cache-on-failure: "true"
           cache-workspace-crates: "true"
           workspaces: |
             daemon -> target
@@ -63,14 +65,9 @@ jobs:
         run: cargo make lint
 
   test:
-    needs: lint
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Maximize build space
-        if: runner.os == 'Linux'
         uses: AdityaGarg8/remove-unwanted-software@v5
         with:
           remove-dotnet: true
@@ -90,17 +87,22 @@ jobs:
         with:
           version: "20.1"
           directory: ${{ runner.temp }}/llvm
+          cached: true
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          shared-key: "${{ matrix.os }}-test-slim"
+          shared-key: "ubuntu-latest-slim"
+          cache-on-failure: "true"
           cache-workspace-crates: "true"
           workspaces: |
             daemon -> target
 
       - name: Test
-        run: cargo test
+        run: cargo nextest run


### PR DESCRIPTION
## Summary

- lint/test ジョブを並列化（`needs: lint` を削除）
- `test-daemon-slim` の test を ubuntu-latest のみに削減（windows/macos は `test-daemon-all` に任せる）
- lint/test の `shared-key` を統一し、test が lint のコンパイル済み依存クレートキャッシュを再利用できるように
- `rust-cache` に `cache-on-failure: true` を追加（ビルド失敗時もキャッシュ保存）
- LLVM インストールに `cached: true` を追加（再ダウンロードを排除）
- `cargo test` → `cargo nextest run` に変更（プロセス並列によるテスト高速化）

## Test plan

- [ ] `test-daemon-slim` が feature branch push で正常に動作することを確認
- [ ] lint と test が並列で起動することを確認
- [ ] rust-cache のキャッシュヒットログを確認（2回目以降のビルド）
- [ ] nextest がすべてのテストを正常に実行することを確認