### PR TITLE
fix: gen-interface.sh に --yes フラグと cargo fmt を追加

### DIFF
--- a/daemon/entrypoints/gen-interface.sh
+++ b/daemon/entrypoints/gen-interface.sh
@@ -6,8 +6,10 @@ cd "$script_dir"
 
 rm -rf ./interface
 
-npx @openapitools/openapi-generator-cli@v2.38.0 generate \
+npx --yes @openapitools/openapi-generator-cli@v2.38.0 generate \
   -i ../openapi.yaml \
   -g rust-axum \
   -o ./interface \
   --additional-properties=packageName=omnius-axus-interface,packageVersion=0.1.0
+
+cargo fmt --all


### PR DESCRIPTION
## Summary
- `npx` コマンドに `--yes` フラグを追加し、インタラクティブなプロンプトをスキップ
- コード生成後に `cargo fmt --all` を実行してフォーマットを自動適用