### PR TITLE
docs: 設計書と既知の不具合一覧を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Axus"]
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ sudo apt-get install -y libclang-dev
 ```
 This package is required for RocksDB.
 
+## Docs
+
+- [DESIGN.md](./docs/DESIGN.md)
+- [ISSUES.md](./docs/ISSUES.md)
+
 ## Links
 
 - Official Documentation: https://docs.omnius-labs.com/

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,668 @@
+# Axus 設計書
+
+## 1. このドキュメントについて
+
+本書は、Axus の Rust 製 daemon が P2P ネットワーク上でノードを探索し、ファイルを公開および購読するための設計を扱う。
+主な読者は、`daemon/` の実装を変更する開発者と、設計判断を引き継ぐ AI エージェントである。
+本書は責務、不変条件、採用理由、保留中の論点を記録し、コードから機械的に取得できる定義の一覧は複写しない。
+
+### 1.1 文書間の責務分担
+
+| 文書または定義                                           | 正とする内容                                                       |
+| -------------------------------------------------------- | ------------------------------------------------------------------ |
+| 本書                                                     | daemon の責務、不変条件、設計判断、保留中の論点                    |
+| [ISSUES.md](./ISSUES.md)                                 | コードで確認した明確な不具合と起票候補                             |
+| [README.md](../README.md)                                | プロジェクト概要、セットアップ、開発手順                           |
+| [openapi.yaml](../daemon/openapi.yaml)                   | REST API のパス、型、ステータスコード                              |
+| [entrypoints/interface](../daemon/entrypoints/interface) | OpenAPI から生成する Rust interface                                |
+| [Rust ソース](../daemon)                                 | バイト列の形式、シリアライズのフィールド番号、定数、依存バージョン |
+
+本書には API の網羅的な一覧、RocketPack のフィールド番号、セットアップ手順、既知の不具合を置かない。
+生成された `entrypoints/interface` は確認対象ではあるが、設計変更の編集先にはしない。
+
+### 1.2 本書の時制について
+
+§2 から §11 は、Axus が満たす設計を現在形で記述する。
+実装がその設計にどこまで到達しているかは §13 にだけ記述する。
+いま何が動くのかを知りたい場合は §13 を先に読む。
+
+## 2. Axus daemon とは
+
+Axus は、Web of Trust による保護を目標に掲げる P2P ファイル共有サービスである。
+daemon は 1 ノード分のネットワーク接続、ノード探索、ファイルの符号化と復号、永続状態、ローカルクライアント向け REST API を 1 プロセスにまとめる。
+ネットワーク規模、1 ノードあたりの利用者数、公開範囲の上限は、コードと既存文書からは確定できない。
+
+### 2.1 スコープ外
+
+コードと README から、プロダクトとして作らないと決めた機能は確認できない。
+そのため本節では、本書の設計対象外だけを定める。
+
+- daemon を操作する GUI と、その画面遷移は扱わない。
+- 配布、監視、バックアップを含む運用基盤は扱わない。
+- `core-rs` の内部設計は扱わず、Axus から見た契約だけを扱う。
+- REST API と RocketPack の完全な wire format は、それぞれの正本に委ねる。
+
+これらを本書の対象外とすることで、クライアント UI、配置トポロジー、外部定義の複写を設計書に持たずに済む。
+
+## 3. 全体構成
+
+### 3.1 コンポーネントとディレクトリ対応表
+
+| パス                                                            | パッケージ名            | 役割                                                         |
+| --------------------------------------------------------------- | ----------------------- | ------------------------------------------------------------ |
+| [daemon/entrypoints/daemon](../daemon/entrypoints/daemon)       | `omnius-axus-daemon`    | CLI、設定、プロセスのライフサイクル、REST API の実装         |
+| [daemon/entrypoints/interface](../daemon/entrypoints/interface) | `omnius-axus-interface` | OpenAPI から生成する axum router と型であり、手で編集しない  |
+| [daemon/modules/engine](../daemon/modules/engine)               | `omnius-axus-engine`    | セッション、ノード探索、ファイル交換、永続化                 |
+| [daemon/refs/core-rs](../daemon/refs/core-rs)                   | `omnius-core-*`         | 時刻、ID、署名、シリアライズ、マイグレーションなどの共通基盤 |
+
+`daemon/` は Cargo workspace のルートであり、`core-rs` の必要な crate を workspace member として直接ビルドする。
+
+### 3.2 処理の流れ
+
+クライアントから P2P 通信までの責務は、上位から下位へ一方向に渡す。
+
+```mermaid
+flowchart TD
+    Client[ローカルクライアント]
+    Api[ApiServer]
+    State[DaemonState]
+    Service[AxusService]
+    Exchanger[FileExchanger]
+    Publisher[FilePublisher]
+    Subscriber[FileSubscriber]
+    Finder[NodeFinder]
+    Session[SessionConnector / SessionAccepter]
+    Transport[TCP / FramedStream]
+    Peer[相手ノード]
+    Meta[(SQLite)]
+    Blocks[(RocksDB)]
+
+    Client --> Api
+    Api --> State
+    State --> Service
+    Service --> Finder
+    Service --> Exchanger
+    Exchanger --> Publisher
+    Exchanger --> Subscriber
+    Exchanger --> Finder
+    Finder --> Session
+    Exchanger --> Session
+    Session --> Transport
+    Transport --> Peer
+    Finder --> Meta
+    Publisher --> Meta
+    Subscriber --> Meta
+    Publisher --> Blocks
+    Subscriber --> Blocks
+```
+
+API 層は engine を知るが、NodeFinder は FilePublisher と FileSubscriber を知らず、探索結果だけを返す。
+この依存方向により、探索規則とファイルの意味論を別々に変更できる。
+
+## 4. 中心概念
+
+### 4.1 NodeProfile
+
+**NodeProfile** は、P2P ネットワーク上の 1 ノードを探索するための識別子と到達先の組である。
+コード上では [NodeProfile](../daemon/modules/engine/src/model/node_profile.rs) が `id` と複数の `OmniAddr` を持ち、外部表現では `axus:node/` から始まる URI になる。
+NodeProfile の `id` は DHT の距離計算に使う値であり、セッションで相手が提示する署名鍵とは別の概念である。
+
+### 4.2 Session
+
+**Session** は、TCP 接続に相手の証明書、接続方向、用途を加えた通信路である。
+コード上では [Session](../daemon/modules/engine/src/core/session/model.rs) が `SessionType`、`SessionHandshakeType`、`OmniCert`、`FramedStream` を保持する。
+Session が証明するのはチャレンジに応答した鍵の所持であり、その相手を信頼してよいことまでは含まない。
+
+### 4.3 AssetKey
+
+**AssetKey** は、NodeFinder が所在を探索する対象の識別子である。
+コード上では [AssetKey](../daemon/modules/engine/src/model/asset_key.rs) が文字列の種別と `OmniHash` を持つ。
+AssetKey はネットワーク上の探索キーであり、表示名を含む FileRef や、所在を表す NodeProfile とは異なる。
+
+### 4.4 FileRef
+
+**FileRef** は、公開済みファイルを上位のデータモデルから参照するための名前とハッシュの組である。
+コード上では [FileRef](../daemon/modules/engine/src/model/file_ref.rs) が `name` と `OmniHash` を持つ。
+FileRef はファイル本体を含まず、NodeFinder の探索結果も含まない。
+
+### 4.5 Profile と memo
+
+**Profile** は、Web of Trust における主体の公開情報と、その主体が公開するデータを指す FileRef 群をまとめる概念である。
+Profile のコード上の型名と外部表現は §12.2 で保留している。
+**memo** は Profile を探索、交換、配布する下位機構を指し、投稿本文や添付データそのものを指さない。
+
+### 4.6 rank と root hash
+
+**rank** は Merkle 構造の階層であり、rank 0 がファイル本体のブロックを表す。
+コード上では [MerkleLayer](../daemon/modules/engine/src/core/negotiator/file/model/merkle_layer.rs) が rank と下位ブロックのハッシュ列を持つ。
+**root hash** は最上位の単一ブロックのハッシュであり、ファイル名や保存場所から独立した内容識別子である。
+
+## 5. daemon と API 層
+
+### 5.1 プロセスのライフサイクル
+
+[Executor](../daemon/entrypoints/daemon/src/executor.rs) は設定ディレクトリを決定し、ファイルロックを取得して多重起動を防ぐ。
+続いて設定と logging を初期化し、[DaemonState](../daemon/entrypoints/daemon/src/state.rs) を構築して [ApiServer](../daemon/entrypoints/daemon/src/server.rs) を起動する。
+SIGINT または SIGTERM は共通の cancellation token に変換し、HTTP server と engine の停止を同じプロセス境界で管理する。
+
+DaemonState は daemon の所有物を保持し、終了時には `AxusService::shutdown()` を起点として下位タスクを停止する。
+所有関係と停止順序を同じ階層にすることで、バックグラウンドタスクの取り残しを防ぐ。
+
+### 5.2 設定の境界
+
+[config.rs](../daemon/entrypoints/daemon/src/config.rs) は、永続状態の置き場、待ち受けアドレス、logging を外部設定から内部型へ変換する。
+HTTP API と P2P transport は別の待ち受け口であるため、両者のアドレスを別々に設定できなければならない。
+一時ディレクトリはプロセス寿命に従い、再起動後も必要な情報は `state_dir` 配下に置く。
+
+設定ファイル名、既定値、CLI オプションの正は README とコードに置く。
+本書は、API と P2P の設定を混同しないこと、および永続状態と一時状態を分けることだけを規定する。
+
+### 5.3 OpenAPI からのコード生成
+
+REST API は [openapi.yaml](../daemon/openapi.yaml) を契約の正とし、生成物と手書き実装を分ける。
+
+```mermaid
+flowchart LR
+    Spec[openapi.yaml]
+    Script[gen-interface.sh]
+    Generated[entrypoints/interface]
+    Handler[entrypoints/daemon ApiServer]
+    Router[axum Router]
+
+    Spec --> Script
+    Script --> Generated
+    Generated --> Handler
+    Generated --> Router
+    Handler --> Router
+```
+
+生成物を毎回作り直せることが前提なので、API 変更は OpenAPI と handler 実装にだけ加える。
+この境界により、schema と router の手編集による食い違いを防ぐ。
+
+## 6. transport と session
+
+### 6.1 接続とフレーム化
+
+[connection](../daemon/modules/engine/src/base/connection.rs) は、TCP の受理と発信を trait の背後に置く。
+発信側は直接 TCP と SOCKS5 proxy を同じ境界で扱い、受理側は必要に応じて UPnP の port mapping を扱う。
+上位層は接続方法ではなく、`FramedStream` が提供する長さ区切りのメッセージ列だけを利用する。
+
+RocketPack の encode と decode は [framed.rs](../daemon/modules/engine/src/base/connection/stream/framed.rs) の拡張を通す。
+これにより session と negotiator は、TCP の partial read やメッセージ境界を扱わずに済む。
+
+### 6.2 session の確立
+
+発信側と受理側は、version、challenge、signature、用途の順に合意する。
+
+```mermaid
+sequenceDiagram
+    participant C as Connector
+    participant A as Accepter
+
+    C->>A: TCP connect
+    par version の交換
+        C->>A: HelloMessage
+        A->>C: HelloMessage
+    end
+    par challenge の交換
+        C->>A: V1ChallengeMessage
+        A->>C: V1ChallengeMessage
+    end
+    par signature の交換
+        C->>A: V1SignatureMessage
+        A->>C: V1SignatureMessage
+    end
+    Note over C,A: 各自が送った challenge への署名を検証する
+    C->>A: V1RequestMessage
+    A->>C: V1ResultMessage
+    Note over C,A: Accept の場合だけ Session を上位へ渡す
+```
+
+用途の確定を認証の後に置くことで、未認証の接続を NodeFinder や FileExchanger のキューに入れない。
+version 交渉は、双方が共通して対応する手順だけを選ばなければならない。
+
+### 6.3 用途と停止
+
+1 本の Session は NodeFinder または FileExchanger のどちらか一方に割り当てる。
+用途ごとの受理キューと接続上限を分けることで、一方の負荷が他方の接続枠を使い切ることを防ぐ。
+用途間の多重化を session 層に持ち込まないため、上位 protocol は自分の message だけを処理する。
+
+[Shutdown](../daemon/modules/engine/src/base/runtime/shutdown.rs) は、所有する下位 component を順に停止するための共通契約である。
+worker は cancellation token または join handle を通じて停止し、所有者の寿命を越えて残らない。
+
+## 7. NodeFinder
+
+### 7.1 責務
+
+[NodeFinder](../daemon/modules/engine/src/core/negotiator/node/node_finder.rs) は、既知ノードの交換と、AssetKey を提供または要求するノードの所在情報を扱う。
+NodeFinder はアセットの内容を解釈せず、AssetKey と NodeProfile の対応だけを返す。
+FileExchanger はこの境界を使うため、ノード探索の message とファイル交換の message を混在させない。
+
+[NodeProfileFetcher](../daemon/modules/engine/src/core/negotiator/node/node_profile_fetcher.rs) は bootstrap 用の NodeProfile 群を外部から取得する。
+URI 変換の詳細と checksum は [converter/uri.rs](../daemon/modules/engine/src/model/converter/uri.rs) が正である。
+
+### 7.2 情報の配布
+
+NodeFinder は要求、回答、自発的な広告を分けて伝播させる。
+
+```mermaid
+flowchart LR
+    Want[want_asset_keys]
+    Give[give_asset_key_locations]
+    Push[push_asset_key_locations]
+    Nodes[push_node_profiles]
+    Near[AssetKey に近いノード]
+    Asker[要求元ノード]
+    All[接続先]
+    Repo[(NodeFinderRepo)]
+
+    Want --> Near
+    Push --> Near
+    Near --> Give
+    Give --> Asker
+    Nodes --> All
+    All --> Repo
+```
+
+要求と広告を XOR 距離の近いノードへ寄せる一方、回答は要求元へ戻す。
+受信情報には寿命と件数上限を設け、古い所在情報と無制限な中継を残さない。
+
+### 7.3 判断と通信の分離
+
+[TaskComputer](../daemon/modules/engine/src/core/negotiator/node/task_computer.rs) は、全 session の受信状態と上位 component の要求を見て、次に送る DataMessage を計算する。
+[TaskCommunicator](../daemon/modules/engine/src/core/negotiator/node/task_communicator.rs) は、session ごとの handshake と送受信だけを担当する。
+判断を 1 箇所へ集約することで、接続ごとの worker に routing policy が分散しない。
+
+FileExchanger から必要な AssetKey を受け取る境界には [FnHub](../daemon/modules/engine/src/base/sync/fn_hub.rs) を使う。
+発火側と登録側を分けることで、NodeFinder は FileExchanger の具象型を参照しない。
+
+### 7.4 距離と永続化
+
+[Kadex](../daemon/modules/engine/src/core/negotiator/node/kadx.rs) は AssetKey の hash と NodeProfile の ID の XOR 距離を比較し、近いノードを選ぶ。
+距離計算の byte order は protocol の相互運用性に関わるため、別実装を追加する場合はコード上の規則を外部仕様へ昇格させる。
+
+[NodeFinderRepo](../daemon/modules/engine/src/core/negotiator/node/node_finder_repo.rs) は既知ノードを URI 表現のまま SQLite に保存する。
+URI を opaque な値として保存することで形式追加のたびに table schema を変えずに済むが、address 単位の SQL 検索は行えない。
+
+## 8. ファイルの公開と購読
+
+### 8.1 責務の分割
+
+[FilePublisher](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher.rs) はローカルファイルを block と Merkle layer に変換し、公開可能な root hash を確定する。
+[FileSubscriber](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber.rs) は root hash から必要な block を管理し、揃った layer を上位から順に復号する。
+[FileExchanger](../daemon/modules/engine/src/core/negotiator/file/file_exchanger.rs) は NodeFinder の探索結果を使って相手と Session を張り、publisher と subscriber の block を運ぶ。
+
+符号化、転送、復号を分けることで、local storage の処理を network session の寿命から独立させる。
+publisher と subscriber は公開用と購読用の状態を共有しない。
+
+### 8.2 Merkle 構造
+
+ファイル本体を rank 0 の固定長 block に分け、各 block の hash 列を上位の MerkleLayer として再帰的に block 化する。
+
+```mermaid
+flowchart BT
+    B0[rank 0 block 0]
+    B1[rank 0 block 1]
+    BN[rank 0 block n]
+    L1[rank 1 MerkleLayer]
+    LX[上位 MerkleLayer]
+    Root[root hash]
+
+    B0 --> L1
+    B1 --> L1
+    BN --> L1
+    L1 --> LX
+    LX --> Root
+```
+
+root hash から下位 block の hash を段階的に得られるため、受信者はファイル全体の hash 一覧を事前に持つ必要がない。
+各受信 block は期待する hash と照合してから保存または復号に使う。
+
+MerkleLayer の rank は encoder と decoder が同じ意味で解釈しなければならない。
+wire format と field 番号は [merkle_layer.rs](../daemon/modules/engine/src/core/negotiator/file/model/merkle_layer.rs) が正である。
+
+### 8.3 状態遷移
+
+公開側は root hash の確定前後を uncommitted と committed に分ける。
+
+```mermaid
+stateDiagram-v2
+    [*] --> Uncommitted
+    Uncommitted --> Committed: root hash を確定して公開する
+    Uncommitted --> Failed
+    Uncommitted --> Canceled
+```
+
+root hash が確定するまでは一時 ID を使い、確定後に内容識別子へ commit する。
+この分離により、途中失敗した処理とネットワークへ広告可能なファイルを区別できる。
+
+購読側は block の取得と layer の復号を交互に進める。
+
+```mermaid
+stateDiagram-v2
+    [*] --> Downloading
+    Downloading --> Decoding: rank の block が揃う
+    Decoding --> Downloading: 次の rank がある
+    Decoding --> Completed: rank 0 を書き出す
+    Downloading --> Failed
+    Decoding --> Failed
+    Downloading --> Canceled
+    Decoding --> Canceled
+```
+
+復号中に得た次の rank の hash 群が、次の Downloading の取得対象になる。
+外部 API は内部状態名をそのまま公開せず、§12.2 の長時間操作の表現に従って安定した契約へ変換する。
+
+### 8.4 接続相手と block の検証
+
+公開側は自分が提供する AssetKey を要求するノードへ接続し、購読側は目的の AssetKey を提供するノードへ接続する。
+相手の探索は NodeFinder に委ね、FileExchanger は探索 algorithm を持たない。
+公開用、購読用、受理用の接続枠を分け、転送方向ごとの資源を確保する。
+
+block 交換 protocol は、要求した hash、受信した hash、保存した block の対応を追跡しなければならない。
+汚染 block を永続化しないため、内容 hash の検証は commit より前に行う。
+
+## 9. 永続化
+
+### 9.1 metadata と block の分離
+
+| 種別     | 実体                              | 保存するもの                          |
+| -------- | --------------------------------- | ------------------------------------- |
+| metadata | SQLite と `omnius-core-migration` | 既知ノード、ファイル状態、block index |
+| block    | `KeyValueRocksdbStorage`          | ファイル本体と MerkleLayer の byte 列 |
+
+metadata は条件検索と状態遷移を必要とするため SQLite に置く。
+block は hash key による読み書きが中心であり、大きな byte 列を metadata query から分離するため RocksDB に置く。
+
+### 9.2 `state_dir` の構造
+
+永続状態は component ごとに directory を分ける。
+
+```text
+<state_dir>/
+├── repo/
+├── file_publisher/
+│   ├── repo/
+│   └── blocks/
+└── file_subscriber/
+    ├── repo/
+    └── blocks/
+```
+
+publisher と subscriber の保存領域を分けることで、一方の再構築や削除が他方の状態を直接壊さない。
+directory 名の追加や移行が必要な場合は migration と rollback の単位を明示する。
+
+### 9.3 論理 key と block 実体
+
+[KeyValueRocksdbStorage](../daemon/modules/engine/src/base/storage/key_value_rocksdb_storage.rs) は、論理 key から内部 ID を引く `names` と、内部 ID から実体を引く `blocks` および `metas` を分ける。
+公開処理の commit は論理 key を uncommitted から committed へ変更し、同じ block 実体を再利用する。
+
+**rename の原子性は、対象が同じ RocksDB transaction 内にあることを前提とする。**
+別 database または別 filesystem へまたがる移動を追加した場合、この前提は崩れ、copy と recovery protocol が必要になる。
+
+### 9.4 schema migration
+
+[publisher_repo.rs](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs)、[subscriber_repo.rs](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs)、[node_finder_repo.rs](../daemon/modules/engine/src/core/negotiator/node/node_finder_repo.rs) は、名前付きの MigrationRequest を順に適用する。
+適用済みの名前を持つ migration は再実行しない。
+
+配布済みの状態へ適用され得る migration は書き換えず、新しい名前の migration で前進させる。
+初回 release 前の migration を直接修正する場合でも、適用済み状態が存在しないことを確認し、その確認結果を変更記録に残す。
+
+## 10. セキュリティ境界
+
+### 10.1 保証の分担
+
+| 機構                           | 保証するもの                            | 保証しないもの                                 |
+| ------------------------------ | --------------------------------------- | ---------------------------------------------- |
+| session の challenge signature | 相手が応答に使った秘密鍵を所持すること  | DHT 上の NodeProfile.id との結合、相手への信頼 |
+| FramedStream                   | message 境界                            | 通信内容の機密性と改竄検出                     |
+| Merkle hash                    | 期待する hash に対する block 内容の一致 | 提供者の信頼性、検索結果の正当性               |
+| Web of Trust                   | §12.2 で決める信頼 policy               | transport の暗号化と block の内容検証          |
+
+認証、暗号化、内容 hash、信頼評価は別の保証であり、どれか 1 つで他を代替しない。
+特に session 認証が成功しても、相手の NodeProfile と公開内容を信頼できるとは限らない。
+
+### 10.2 脅威モデル
+
+NodeProfile.id を低コストで選べる場合、攻撃者は AssetKey に近い ID を集める Sybil 攻撃と Eclipse 攻撃を行える。
+既知ノードと伝播情報の件数上限は資源消費を抑えるが、攻撃者の情報だけが残ることは防がない。
+Web of Trust はこの信頼選別を担うが、transport の盗聴と改竄には別の secure channel が必要である。
+
+NodeFinder の中継は情報を増幅し得るため、TTL、件数、接続数、message size の上限を protocol の入力境界で強制する。
+FileExchanger は受信 block を hash 検証し、Profile 交換は署名と version 検証を通す。
+
+## 11. Profile と memo
+
+### 11.1 Profile が参照するデータ
+
+Profile は投稿本文や添付 byte 列を直接埋め込まず、公開済み File の FileRef を保持する。
+投稿群をまとめた File と、利用者が個別に公開した File は、どちらも先に FilePublisher へ渡して root hash を得る。
+上位サービス層はその結果から FileRef を構築し、Profile の分類規則に従って登録する。
+
+この構造により、大きなデータの配布と Profile の更新を同じ protocol に重ねずに済む。
+Profile の真正性を検証しても、参照先 File の block hash 検証は省略しない。
+
+### 11.2 層ごとの責務
+
+| 層                             | 責務                                                   | 知らないもの         |
+| ------------------------------ | ------------------------------------------------------ | -------------------- |
+| FilePublisher と FileExchanger | File の公開、探索、block 転送                          | 投稿、Profile の意味 |
+| 将来の MemoExchanger           | Profile の探索、交換、配布                             | 投稿本文、添付の解釈 |
+| 上位サービス層                 | 投稿データの構築、FileRef の分類、Profile の生成と更新 | block 転送の詳細     |
+
+下位層は Profile を opaque な payload として扱い、上位層だけが FileRef の意味を解釈する。
+この境界により、掲示板や timeline のデータモデルを変えても、memo の探索と配布を作り直さずに済む。
+
+## 12. 設計判断
+
+### 12.1 決定済み
+
+#### OpenAPI を REST 契約の正とする
+
+**決定**
+REST API の path、schema、status code は `openapi.yaml` で定義し、Rust interface は生成する。
+
+**理由**
+schema、router、client が別々の定義を持つ状態を避け、変更点を 1 箇所に集約するためである。
+
+**却下案**
+生成された interface の直接編集は、再生成で失われ、OpenAPI と実装を食い違わせるため採用しない。
+
+#### 1 Session を 1 用途に割り当てる
+
+**決定**
+NodeFinder と FileExchanger は別の Session を使い、用途ごとの受理 queue と接続上限を持つ。
+
+**理由**
+message protocol と接続資源を用途ごとに隔離し、一方の負荷が他方の処理を占有しないようにするためである。
+
+#### 探索とファイル交換を分離する
+
+**決定**
+NodeFinder は AssetKey から NodeProfile を探し、FileExchanger はその結果を使って block を交換する。
+
+**理由**
+探索 algorithm がファイル形式を知らず、publisher と subscriber が DHT message を知らない依存方向を保つためである。
+
+#### metadata と block 実体を別の storage に置く
+
+**決定**
+検索と状態遷移を伴う metadata は SQLite に置き、hash key で扱う block 実体は RocksDB に置く。
+
+**理由**
+関係 query と大きな byte 列の読み書きを同じ storage model に押し込めず、それぞれの access pattern に合わせるためである。
+
+#### Profile は公開データを FileRef で参照する
+
+**決定**
+Profile は投稿本文と添付を埋め込まず、FilePublisher で公開したデータの FileRef を保持する。
+MemoExchanger は Profile の意味を解釈せず、探索、交換、配布だけを担う。
+
+**理由**
+内容配布を既存の File protocol に集約し、Profile と掲示板の model を transport から分離するためである。
+
+### 12.2 保留
+
+#### NodeProfile.id と署名鍵の結合
+
+**現状**
+Session は OmniCert を保持し、NodeProfile は独立した ID を持つため、両者を同じ主体として検証する規則がない。
+
+候補は次の 3 つである。
+
+1. 公開鍵から NodeProfile.id を導出すると結合は単純になるが、鍵 rotation で ID が変わる。
+2. 安定した NodeProfile.id と鍵の対応を署名すると rotation を表現できるが、証明 chain と失効処理が必要になる。
+3. 両者を分離したまま trust graph で対応を表すと柔軟だが、すべての照合が複雑になる。
+
+**なぜ今決めないか**
+File の local encoding と NodeFinder の情報交換は、この結合規則がなくても個別に検証できるためである。
+
+**決める条件**
+Profile の主体と真正性を wire format に定義する前、または Web of Trust の edge を実装する前に決める。
+
+#### Session の secure channel
+
+**現状**
+相互 challenge signature の後も Session は FramedStream を使い、暗号化と message authentication の方式は定めていない。
+
+候補は次の 2 つである。
+
+1. `core-rs` の `OmniSecureStream` を適用すると既存部品を再利用できるが、handshake 順序と鍵導出の適合を確認する必要がある。
+2. Session protocol 専用の鍵合意を定義すると用途に合わせられるが、新しい暗号 protocol の設計と監査が必要になる。
+
+**なぜ今決めないか**
+local の構成確認と storage 処理は secure channel の wire format に依存しないためである。
+
+**決める条件**
+信頼できない network で FileExchanger または Profile 交換を有効にする前に決める。
+
+#### Session の version 選択
+
+**現状**
+[session/message.rs](../daemon/modules/engine/src/core/session/message.rs) と [task_communicator.rs](../daemon/modules/engine/src/core/negotiator/node/task_communicator.rs) は、対応 version を bit flag で交換する。
+定義されている version は V1 だけであり、複数の共通 version から 1 つを選ぶ規則は定めていない。
+
+候補は次の 2 つである。
+
+1. 数値が最も大きい共通 version を選ぶと新機能を優先できるが、version 番号と優先順位を常に一致させる必要がある。
+2. 明示的な優先順位表から選ぶと安定版を優先できるが、version 追加のたびに表を更新する必要がある。
+
+**なぜ今決めないか**
+V1 しか存在しないため、どちらの規則でも交渉結果が変わらない。
+
+**決める条件**
+`SessionVersion` または `NodeFinderVersion` に 2 つ目の version を追加する前に決める。
+
+#### NodeFinder の能動探索と冗長度
+
+**現状**
+所在情報は定期的な伝播で集め、lookup は接続中 Session の受信状態を走査する形である。
+
+候補は次の 2 つである。
+
+1. Kademlia 型の反復 query を加えると到達率と遅延を制御できるが、query state、timeout、並列度が増える。
+2. 伝播だけを維持すると protocol は単純だが、情報が届くまでの時間と未到達を制御しにくい。
+
+**なぜ今決めないか**
+実運用規模における lookup の到達率と遅延を測定していないためである。
+
+**決める条件**
+複数 hop の結合試験で、購読開始に必要な所在情報の到達率と遅延を測定した時点で決める。
+
+#### MerkleLayer.rank の意味
+
+**現状**
+MerkleLayer の rank が、その layer を格納する block の rank と、layer が列挙する子 block の rank のどちらを指すかを契約として定めていない。
+
+候補は次の 2 つである。
+
+1. 格納先 block の rank を持たせると encoder の生成位置と一致するが、decoder は次の rank を別途計算する必要がある。
+2. 子 block の rank を持たせると decoder の遷移を直接表せるが、encoder は格納先から 1 を引いて記録する必要がある。
+
+**なぜ今決めないか**
+どちらの意味も Merkle 構造を表現でき、互換性を保証する既存 wire data と encode から decode までの成功試験がないためである。
+
+**決める条件**
+[ISSUES.md](./ISSUES.md) の I-4 を修正する前に決め、選んだ意味を encode と decode の contract test で固定する。
+
+#### Web of Trust の単位と伝播
+
+**現状**
+README は Web of Trust による検索と公開の保護を掲げるが、信頼対象と score の計算規則を定めていない。
+
+候補は次の 2 つである。
+
+1. 直接署名だけを使うと説明と失効が単純だが、未知の主体を評価できない。
+2. 推移的な trust を使うと discovery 範囲が広がるが、深さ、減衰、循環、Sybil 耐性を規定する必要がある。
+
+**なぜ今決めないか**
+NodeProfile.id と署名鍵の結合が先に必要であり、信頼を適用する API も確定していないためである。
+
+**決める条件**
+検索結果または Profile を trust score で選別する最初の API を定義する前に決める。
+
+#### Profile の形式と更新
+
+**現状**
+Profile が FileRef 群を持ち、memo が Profile を配布する責務境界だけを定めている。
+
+候補は次の 2 つである。
+
+1. version 付きの immutable Profile を連鎖させると履歴検証が容易だが、最新版探索と storage 回収が必要になる。
+2. 主体ごとの mutable な最新版を配布すると取得は単純だが、競合、rollback、replay の規則が必要になる。
+
+**なぜ今決めないか**
+identity と Web of Trust の署名対象が決まるまで、Profile の真正性と競合解決を定義できないためである。
+
+**決める条件**
+Profile 型、MemoRef、MemoExchanger のいずれかを protocol surface として実装する前に決める。
+
+#### 長時間 REST 操作の表現
+
+**現状**
+ファイルの符号化、取得、復号は内部状態を持つ長時間処理であり、外部 API への写し方を定めていない。
+
+候補は次の 2 つである。
+
+1. job resource を作って polling させると再接続に強いが、job の保存期間と cancel contract が必要になる。
+2. stream または server-sent event で進捗を返すと即時性があるが、切断時の再開規則が必要になる。
+
+**なぜ今決めないか**
+FilePublisher と FileSubscriber の public operation が daemon 層に接続されるまでは、安定させるべき外部 contract がないためである。
+
+**決める条件**
+公開開始、購読開始、進捗取得の endpoint を `openapi.yaml` に追加する前に決める。
+
+## 13. 現状と残作業
+
+### 13.1 現状
+
+| 領域               | コードで確認した現状                                                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| daemon と REST API | Executor は config、file lock、signal、HTTP server を組み立てるが、DaemonState は AxusService を保持せず、health handler は `todo!()` である |
+| AxusService        | NodeFinder だけを構築して shutdown し、FileExchanger を所有しない                                                                            |
+| session            | version、challenge、signature、用途選択の message があり、Session は暗号化されていない FramedStream を保持する                               |
+| NodeFinder         | 接続、受理、計算、通信の task と SQLite repo があり、lookup は接続中 Session の受信状態だけを走査する                                        |
+| FilePublisher      | File の block 化、MerkleLayer の生成、root hash の確定、commit 用の処理がある                                                                |
+| FileSubscriber     | block の保存と rank ごとの復号処理があるが、購読を作成する daemon API はない                                                                 |
+| FileExchanger      | 接続と受理の task はあるが、block 要求と応答の message および送受信 loop がない                                                              |
+| Profile と memo    | FileRef 型はあるが、memo と MemoRef の module は空であり、Profile 型と上位サービス層はない                                                   |
+| 永続化             | NodeFinder、publisher、subscriber の repo と block storage があるが、ファイル経路には既知の schema 不具合がある                              |
+
+`todo!()` の現物は `rg 'todo!\(' daemon --glob '*.rs' --glob '!target/**'` で確認できる。
+空の module や結線されていない component は、この検索だけでは検出できない。
+
+### 13.2 ロードマップ
+
+次の順序は暫定であり、守る必要があるのは表中の依存関係だけである。
+
+| 番号 | 内容                                                                                 | 前提とする依存                                            |
+| ---- | ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| 1    | HTTP と P2P の設定を分離し、DaemonState が AxusService を所有して停止まで管理する    | §12.2 の secure channel は後から決められる                |
+| 2    | session と NodeFinder を daemon の起動経路から結合試験する                           | 1、関連する既知の不具合の解消                             |
+| 3    | publisher と subscriber の schema を修正し、初期化、符号化、復号を実データで検証する | 適用済み migration の有無の確認                           |
+| 4    | FileExchanger の block 交換 protocol と hash 検証を定義して実装する                  | 2、3、secure channel の判断                               |
+| 5    | 公開、購読、進捗、cancel の REST API を定義する                                      | 4、§12.2 の長時間操作の判断                               |
+| 6    | identity、Web of Trust、Profile、memo を順に定義する                                 | §12.2 の identity と trust の判断、FileRef を解決できる 4 |
+
+確認済みの不具合と修正方針は [ISSUES.md](./ISSUES.md) を参照する。

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,434 @@
+# Axus 既知の不具合
+
+本書は、コードを読んで確認した明確な不具合を扱う。
+設計上の未決事項は扱わず、[DESIGN.md §12.2](./DESIGN.md#122-保留) に置く。
+
+## この文書の使い方
+
+- GitHub Issue に起票したら、一覧表の Issue 列に番号を追記する。
+- 修正されたら、一覧表の行と項目本体を削除する。
+- 行番号はコード変更でずれるため、修正時に該当箇所を再確認する。
+
+調査日: 2026-07-26
+対象コミット: `ac38557`
+
+## 一覧
+
+| ID            | 概要                                                          | 深刻度 | Issue  |
+| ------------- | ------------------------------------------------------------- | ------ | ------ |
+| [I-1](#i-1)   | `DaemonState` が `AxusService` を生成せず、P2P 層が起動しない | 高     | 未起票 |
+| [I-2](#i-2)   | ファイル関連の SQLite schema が初期化時にエラーになる         | 高     | 未起票 |
+| [I-3](#i-3)   | SQL が存在しない列 `property` を参照している                  | 高     | 未起票 |
+| [I-4](#i-4)   | `MerkleLayer.rank` の解釈が encoder と decoder で 1 ずれる    | 高     | 未起票 |
+| [I-5](#i-5)   | FileExchanger 要求で受理 task が panic し、受信が停止する     | 高     | 未起票 |
+| [I-6](#i-6)   | version 交渉が積集合ではなく和集合になっている                | 中     | 未起票 |
+| [I-7](#i-7)   | 署名鍵の識別子が `"TODO"` 固定である                          | 中     | 未起票 |
+| [I-8](#i-8)   | 設定ファイル名が `pxna.toml` のままである                     | 低     | 未起票 |
+| [I-9](#i-9)   | `axus-config.toml` が現在の parser と整合しない               | 低     | 未起票 |
+| [I-10](#i-10) | 設定 test が期待値不一致のまま無効化されている                | 低     | 未起票 |
+
+I-1 は P2P component を daemon から実行するための前提である。
+I-2、I-3、I-4 はファイル公開と購読の同じ経路にあるため、結線前にまとめて修正する。
+I-8、I-9、I-10 は設定ファイルの命名、sample、test に関する同じ経路にあるため、同時に修正する。
+
+<a id="i-1"></a>
+## I-1. `DaemonState` が `AxusService` を生成せず、P2P 層が起動しない
+
+**深刻度: 高**
+
+### 症状
+
+daemon を起動しても P2P 通信が行われない。
+HTTP server だけが待ち受ける。
+
+### 該当箇所
+
+- [state.rs:24](../daemon/entrypoints/daemon/src/state.rs#L24)：`DaemonState::new` は `conf` と `temp_dir` だけを保持して返す。
+- [executor.rs:100](../daemon/entrypoints/daemon/src/executor.rs#L100)：`state.engine.shutdown()` はコメントアウトされている。
+
+### 原因
+
+`DaemonState` が `AxusService` を生成して保持する処理がない。
+
+### 影響
+
+daemon の通常の起動経路から P2P component を利用できない。
+I-2 から I-7 の経路を daemon として実行する前提も成立しない。
+
+### 対応方針
+
+`DaemonState` に `AxusService` を保持させる。
+`Executor::handle_start` の終了時に `AxusService::shutdown()` を呼ぶ。
+HTTP API と P2P の待ち受けアドレスは [DESIGN.md §5.2](./DESIGN.md#52-設定の境界) に従って分離する。
+FileExchanger の結線は I-2、I-3、I-4 の修正後に行う。
+
+<a id="i-2"></a>
+## I-2. ファイル関連の SQLite schema が初期化時にエラーになる
+
+**深刻度: 高**（I-1 により現時点では未顕在）
+
+### 症状
+
+`FilePublisherRepo::new` と `FileSubscriberRepo::new` が migration の適用時にエラーを返す。
+そのため `FilePublisher` と `FileSubscriber` を構築できない。
+
+### 該当箇所
+
+publisher 側の索引定義は [publisher_repo.rs:82](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs#L82) にある。
+
+```sql
+CREATE INDEX IF NOT EXISTS index_file_id_rank_index_for_uncommitted_blocks
+    ON committed_blocks (file_id, rank ASC, `index` ASC);
+```
+
+索引名は `uncommitted_blocks` 用だが、対象 table は `committed_blocks` である。
+`committed_blocks` は `root_hash` を持つ一方で、`file_id` を持たない。
+
+subscriber 側の `files` table は [subscriber_repo.rs:41](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L41) にある。
+
+1. [subscriber_repo.rs:42](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L42) と [subscriber_repo.rs:54](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L54) が primary key を二重に宣言している。
+2. [subscriber_repo.rs:54](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L54) が table に存在しない `file_name` を参照している。
+3. [subscriber_repo.rs:45](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L45) は `depth` を定義するが、[SubscribedFile:6](../daemon/modules/engine/src/core/negotiator/file/model/subscribed_file.rs#L6) の対応 field は `rank` である。
+4. [subscriber_repo.rs:64](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L64) の索引は `is_downloaded` を参照するが、`blocks` table の列名は `downloaded` である。
+
+### 原因
+
+migration の SQL と、対象 table および model の名前が一致していない。
+
+### 影響
+
+ファイル公開と購読の repository を初期化できない。
+I-1 により FileExchanger が daemon から構築されないため、現在の通常起動では顕在化しない。
+
+### 対応方針
+
+対象 table と model に合わせて索引、primary key、列名を修正する。
+既存 MigrationRequest を直接修正できるかは、[DESIGN.md §9.4](./DESIGN.md#94-schema-migration) に従って判断する。
+適用済み環境が存在しないことを確認できた場合に限り、既存 MigrationRequest を直接修正する。
+適用済み環境が存在する場合、または存在しないことを確認できない場合は、新しい MigrationRequest を追加する。
+修正後は publisher と subscriber の初期化 test を追加する。
+
+<a id="i-3"></a>
+## I-3. SQL が存在しない列 `property` を参照している
+
+**深刻度: 高**（I-1 と I-2 により現時点では未顕在）
+
+### 症状
+
+ファイル情報を取得または挿入する query が `no such column: property` で失敗する。
+
+### 該当箇所
+
+どの対象 table にも `property` 列はない。
+
+| ファイル             | 該当行                                                                                                                                                                                                                                                                                                                                                                                               | 対応する列 |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `publisher_repo.rs`  | [111](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs#L111)、[125](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs#L125)                                                                                                                                                                                                       | `attrs`    |
+| `publisher_repo.rs`  | [301](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs#L301)、[330](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs#L330)                                                                                                                                                                                                       | `attrs`    |
+| `subscriber_repo.rs` | [91](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L91)、[106](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L106)、[121](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L121)、[138](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L138) | `priority` |
+
+subscriber 側では `attrs` が別に選択されているため、`property` は `priority` の位置にある。
+publisher 側では `property` が `attrs` の位置にある。
+[subscriber_repo.rs:308](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs#L308) の `INSERT` は `attrs` と `priority` を使っている。
+
+### 原因
+
+query の列名が table schema および model と一致していない。
+
+### 影響
+
+I-2 を修正して repository を初期化できても、対象 query は失敗する。
+ファイル公開と購読の処理を継続できない。
+
+### 対応方針
+
+publisher 側の `property` を `attrs` に置換する。
+subscriber 側の `property` を `priority` に置換する。
+I-2 の `depth` と `rank` の不一致も同時に修正する。
+再発防止として、`sqlx::query!` による compile 時検証を導入できるか検討する。
+
+<a id="i-4"></a>
+## I-4. `MerkleLayer.rank` の解釈が encoder と decoder で 1 ずれる
+
+**深刻度: 高**（購読開始の入口がなく現時点では未顕在）
+
+### 症状
+
+ファイルの復号が最初の Merkle layer で `InvalidFormat` を返す。
+
+### 該当箇所
+
+encoder は [task_encoder.rs:228](../daemon/modules/engine/src/core/negotiator/file/file_publisher/task_encoder.rs#L228) で、格納先 block と同じ rank を記録する。
+
+```rust
+let mut rank = 1;
+loop {
+    let merkle_layer = MerkleLayer {
+        rank,
+        hashes: std::mem::take(&mut current_block_hashes),
+    };
+```
+
+decoder は [task_decoder.rs:203](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/task_decoder.rs#L203) で、格納先 block より 1 小さい rank を期待する。
+
+```rust
+if merkle_layer.rank != (file.rank - 1) {
+    return Err(Error::new(ErrorKind::InvalidFormat));
+}
+```
+
+### 原因
+
+`MerkleLayer.rank` が格納先 block と子 block のどちらの rank を表すかが確定していない。
+encoder と decoder は異なる意味で実装されている。
+
+### 影響
+
+購読側の復号が成立しない。
+購読開始の入口がないため、現在の daemon API からは顕在化しない。
+
+### 対応方針
+
+[DESIGN.md §12.2](./DESIGN.md#merklelayerrank-の意味) で rank の意味を決める。
+決定した意味に合わせて encoder と decoder を同時に修正する。
+encode から decode までの round-trip test で契約を固定する。
+
+<a id="i-5"></a>
+## I-5. FileExchanger 要求で受理 task が panic し、受信が停止する
+
+**深刻度: 高**（通常の daemon では I-1 により未顕在、AxusService 起動時は外部から誘発可能）
+
+### 症状
+
+`AxusService` を起動したノードへ `SessionType::FileExchanger` の接続要求を 3 回送ると、着信を処理する task がすべて停止する。
+process は生存するが、それ以降の着信を受理できない。
+
+### 該当箇所
+
+[accepter.rs:50](../daemon/modules/engine/src/core/session/accepter.rs#L50) は `NodeFinder` 用の受理 queue だけを作る。
+
+```rust
+for typ in [SessionType::NodeFinder].iter() {
+    let (tx, rx) = mpsc::channel(20);
+}
+```
+
+[accepter.rs:194](../daemon/modules/engine/src/core/session/accepter.rs#L194) は request された種別の queue を `unwrap()` で取り出す。
+
+```rust
+if let Ok(permit) = self.senders.lock().await.get(&typ).unwrap().try_reserve() {
+```
+
+`typ` が `FileExchanger` の場合、`get()` は `None` を返す。
+その結果、`unwrap()` が panic する。
+
+### 原因
+
+SessionType の追加と受理 queue の初期化対象が同期していない。
+外部 request から決まる値に対して `unwrap()` を使っている。
+
+### 影響
+
+`TaskAccepter` は 3 本あり、1 回の panic で 1 本ずつ停止する。
+3 回の要求で着信用 task がすべて停止する。
+[AxusService::create_node_finder](../daemon/modules/engine/src/service.rs#L41) は SessionAccepter を構築するため、AxusService を起動する経路では外部から誘発できる。
+通常の daemon は I-1 により AxusService を構築しないため、現在の通常起動では未顕在である。
+
+### 対応方針
+
+1. 受理 queue をすべての SessionType に対して初期化する。
+2. `unwrap()` を除去し、queue がない種別には `Reject` を返す。
+3. SessionType の追加漏れを compile 時に検出できるよう、全 variant を列挙して初期化する。
+4. FileExchanger request を繰り返しても task が停止しないことを test する。
+
+<a id="i-6"></a>
+## I-6. version 交渉が積集合ではなく和集合になっている
+
+**深刻度: 中**（V1 しか存在しないため現時点では未顕在）
+
+### 症状
+
+対応 version が複数になった場合、双方に共通しない version でも交渉が成立する。
+その結果、互いに解釈できない message を交換する。
+
+### 該当箇所
+
+次の 3 箇所が bit flag の和集合を取っている。
+
+- [connector.rs:36](../daemon/modules/engine/src/core/session/connector.rs#L36)
+- [accepter.rs:169](../daemon/modules/engine/src/core/session/accepter.rs#L169)
+- [task_communicator.rs:149](../daemon/modules/engine/src/core/negotiator/node/task_communicator.rs#L149)
+
+```rust
+let version = send_hello_message.version | received_hello_message.version;
+```
+
+### 原因
+
+双方が対応する version の積集合ではなく、どちらかが対応する version の和集合を計算している。
+
+### 影響
+
+V1 だけが定義されている間は結果が変わらない。
+V2 以降を追加すると、接続成立後に message の解釈が食い違う。
+
+### 対応方針
+
+3 箇所の `|` を `&` に変更する。
+積集合が空の場合は、対応 version がないことを示す error を返す。
+複数の共通 version から 1 つを選ぶ規則は [DESIGN.md §12.2](./DESIGN.md#session-の-version-選択) で決める。
+共通 version がない場合と複数ある場合の test を追加する。
+
+<a id="i-7"></a>
+## I-7. 署名鍵の識別子が `"TODO"` 固定である
+
+**深刻度: 中**（設計論点に依存）
+
+### 症状
+
+すべての AxusService が同じ識別子から署名鍵を生成する。
+
+### 該当箇所
+
+[service.rs:56](../daemon/modules/engine/src/service.rs#L56) が固定文字列を OmniSigner に渡している。
+
+```rust
+let signer = Arc::new(OmniSigner::new(OmniSignType::Ed25519_Sha3_256_Base64Url, "TODO")?);
+```
+
+### 原因
+
+node identity の設計が決まる前の仮値が残っている。
+
+### 影響
+
+session 層の相互認証で node ごとの鍵を識別できない。
+[node_finder.rs:70](../daemon/modules/engine/src/core/negotiator/node/node_finder.rs#L70) が生成する `NodeProfile.id` も署名鍵と結び付いていない。
+
+### 対応方針
+
+[DESIGN.md §12.2](./DESIGN.md#nodeprofileid-と署名鍵の結合) で node identity と署名鍵の関係を決める。
+決定した identity に基づいて signer の識別子と永続化方法を実装する。
+node ごとに異なる鍵が生成または復元されることを test する。
+
+<a id="i-8"></a>
+## I-8. 設定ファイル名が `pxna.toml` のままである
+
+**深刻度: 低**
+
+### 症状
+
+Axus daemon は `axus.toml` ではなく `pxna.toml` という名前の設定ファイルを要求する。
+利用者が Axus の名前から設定ファイルを推測できない。
+
+### 該当箇所
+
+[config.rs:63](../daemon/entrypoints/daemon/src/config.rs#L63) が固定ファイル名を指定している。
+
+```rust
+let toml_path = dir.join("pxna.toml");
+```
+
+[config.rs:91](../daemon/entrypoints/daemon/src/config.rs#L91) の test fixture も同じ名前を使う。
+
+### 原因
+
+設定ファイルの固定名が `pxna.toml` のまま残っている。
+この名前を採用した理由はコードに記録されていない。
+
+### 影響
+
+利用者は Axus と異なる名前の設定ファイルを配置する必要がある。
+README に固定名の説明がないため、設定方法を発見しにくい。
+
+### 対応方針
+
+固定名を `axus.toml` に変更する。
+test fixture と README の設定手順も同じ名前へ更新する。
+I-9 と I-10 を同時に修正する。
+
+<a id="i-9"></a>
+## I-9. `axus-config.toml` が現在の parser と整合しない
+
+**深刻度: 低**（通常の設定読込経路では未顕在）
+
+### 症状
+
+repository にある `axus-config.toml` を現在の parser へ渡すと parse error になる。
+CLI はこのファイルを自動では読み込まない。
+
+### 該当箇所
+
+[axus-config.toml:1](../daemon/axus-config.toml#L1) は section を持たない。
+
+```toml
+listen_addr = "127.0.0.1:5050"
+state_dir = "./state"
+```
+
+[config.rs:8](../daemon/entrypoints/daemon/src/config.rs#L8) の `DaemonConfigToml` は `core` と `logging` を要求する。
+[config.rs:63](../daemon/entrypoints/daemon/src/config.rs#L63) は config directory 配下の固定名ファイルだけを読む。
+
+### 原因
+
+repository 直下の設定例が古い schema と配置方法のまま残っている。
+
+### 影響
+
+通常の設定読込経路ではこのファイルを読まないため、daemon の動作には影響しない。
+repository を読んだ利用者には有効な設定例に見えるため、設定方法を誤解させる。
+
+### 対応方針
+
+現在の schema に合わせた `axus.toml.example` へ置き換える。
+README に sample を config directory へコピーする手順を記載する。
+I-8 で変更する固定名と一致させる。
+
+<a id="i-10"></a>
+## I-10. 設定 test が期待値不一致のまま無効化されている
+
+**深刻度: 低**（`#[ignore]` により現時点では未顕在）
+
+### 症状
+
+通常の test 実行では設定読込 test が実行されない。
+ignore を外して実行すると、fixture と期待値の不一致により失敗する。
+
+### 該当箇所
+
+[config.rs:77](../daemon/entrypoints/daemon/src/config.rs#L77) が test に `#[ignore]` を付けている。
+[config.rs:83](../daemon/entrypoints/daemon/src/config.rs#L83) は `listen_addr` に `0.0.0.0:6051` を設定する。
+[config.rs:96](../daemon/entrypoints/daemon/src/config.rs#L96) は `0.0.0.0:6050` を期待する。
+[config.rs:79](../daemon/entrypoints/daemon/src/config.rs#L79) の test 名は内容と一致しない。
+
+### 原因
+
+期待値と fixture の不一致が修正されないまま、test 全体が ignore されている。
+test 名も以前の用途を示す `secret_reader_test` のままである。
+
+### 影響
+
+CI は設定読込の regression を検出できない。
+現在の test が失敗することも CI から見えない。
+
+### 対応方針
+
+期待値を fixture に合わせる。
+test 名を `load_config_test` へ変更する。
+`#[ignore]` を外して CI で常時実行する。
+I-8 の設定ファイル名変更も同じ test で検証する。
+
+## ここに含めていないもの
+
+次の項目は、確認済みの不具合ではなく、設計判断または新規実装を必要とする。
+対応する設計は DESIGN.md 側で扱う。
+
+| 項目                                        | 参照                                                         |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| session の secure channel がない            | [DESIGN.md §12.2](./DESIGN.md#session-の-secure-channel)     |
+| FileExchanger の block 交換 protocol がない | [DESIGN.md §8.4](./DESIGN.md#84-接続相手と-block-の検証)     |
+| 購読開始の入口がない                        | [DESIGN.md §13.1](./DESIGN.md#131-現状)                      |
+| NodeFinder の能動探索がない                 | [DESIGN.md §12.2](./DESIGN.md#nodefinder-の能動探索と冗長度) |
+| Web of Trust が未設計である                 | [DESIGN.md §12.2](./DESIGN.md#web-of-trust-の単位と伝播)     |
+| Profile と memo が未実装である              | [DESIGN.md §11.2](./DESIGN.md#112-層ごとの責務)              |
+| 長時間 REST 操作の表現が未決である          | [DESIGN.md §12.2](./DESIGN.md#長時間-rest-操作の表現)        |


### PR DESCRIPTION
## 概要

`daemon/` の実装を読み取り、設計文書 `docs/DESIGN.md` と既知の不具合一覧 `docs/ISSUES.md` を新規に追加する。
コードから機械的に取得できる定義（API 一覧、RocketPack のフィールド番号など）は複写せず、責務・不変条件・設計判断・保留中の論点を記録する方針とした。

## 変更内容

### `docs/DESIGN.md`

全 13 章。文書間の責務分担（本書 / ISSUES.md / README.md / openapi.yaml / Rust ソース）を先頭で定義したうえで、以下を記述する。

- 全体構成、中心概念、daemon と API 層
- transport と session、NodeFinder、ファイルの公開と購読、永続化
- セキュリティ境界、Profile と memo
- §12 設計判断（採用理由と却下案、保留中の論点と決める条件）
- §13 現状と残作業（コードで確認した実装状況の表とロードマップ）

§2〜§11 は設計を現在形で記述し、実装の到達度は §13 にのみ書き分けている。

### `docs/ISSUES.md`

コードで確認した不具合を 10 件、深刻度付きで一覧化する。各項目は 症状 / 該当箇所 / 原因 / 影響 / 対応方針 の構成。

| ID | 概要 | 深刻度 |
| --- | --- | --- |
| I-1 | `DaemonState` が `AxusService` を生成せず、P2P 層が起動しない | 高 |
| I-2 | ファイル関連の SQLite schema が初期化時にエラーになる | 高 |
| I-3 | SQL が存在しない列 `property` を参照している | 高 |
| I-4 | `MerkleLayer.rank` の解釈が encoder と decoder で 1 ずれる | 高 |
| I-5 | FileExchanger 要求で受理 task が panic し、受信が停止する | 高 |
| I-6 | version 交渉が積集合ではなく和集合になっている | 中 |
| I-7 | 署名鍵の識別子が `"TODO"` 固定である | 中 |
| I-8 | 設定ファイル名が `pxna.toml` のままである | 低 |
| I-9 | `axus-config.toml` が現在の parser と整合しない | 低 |
| I-10 | 設定 test が期待値不一致のまま無効化されている | 低 |

調査対象コミットは `ac38557`。

### その他

- `README.md`: Docs 節を追加し、両文書へリンク
- `.vscode/settings.json`: cSpell の辞書に `Axus` を登録

## 補足

本 PR は文書のみの変更で、コードの動作には影響しない。
ISSUES.md の各項目は GitHub Issue への起票候補であり、起票後に Issue 番号を追記し、修正後に該当行と項目本体を削除する運用を想定している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)