### PR TITLE
docs: RocketPack 型の生成を設計書に追加

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -15,16 +15,17 @@
 | [README.md](../README.md)                                | プロジェクト概要、セットアップ、開発手順                           |
 | [openapi.yaml](../daemon/openapi.yaml)                   | REST API のパス、型、ステータスコード                              |
 | [entrypoints/interface](../daemon/entrypoints/interface) | OpenAPI から生成する Rust interface                                |
-| [Rust ソース](../daemon)                                 | バイト列の形式、シリアライズのフィールド番号、定数、依存バージョン |
+| rpf ファイル                                             | RocketPack で符号化する型の定義とフィールド番号                    |
+| [Rust ソース](../daemon)                                 | バイト列の形式、定数、依存バージョン                               |
 
 本書には API の網羅的な一覧、RocketPack のフィールド番号、セットアップ手順、既知の不具合を置かない。
 生成された `entrypoints/interface` は確認対象ではあるが、設計変更の編集先にはしない。
 
 ### 1.2 本書の時制について
 
-§2 から §11 は、Axus が満たす設計を現在形で記述する。
-実装がその設計にどこまで到達しているかは §13 にだけ記述する。
-いま何が動くのかを知りたい場合は §13 を先に読む。
+§2 から §12 は、Axus が満たす設計を現在形で記述する。
+実装がその設計にどこまで到達しているかは §14 にだけ記述する。
+いま何が動くのかを知りたい場合は §14 を先に読む。
 
 ## 2. Axus daemon とは
 
@@ -128,7 +129,7 @@ FileRef はファイル本体を含まず、NodeFinder の探索結果も含ま�
 ### 4.5 Profile と memo
 
 **Profile** は、Web of Trust における主体の公開情報と、その主体が公開するデータを指す FileRef 群をまとめる概念である。
-Profile のコード上の型名と外部表現は §12.2 で保留している。
+Profile のコード上の型名と外部表現は §13.2 で保留している。
 **memo** は Profile を探索、交換、配布する下位機構を指し、投稿本文や添付データそのものを指さない。
 
 ### 4.6 rank と root hash
@@ -179,9 +180,68 @@ flowchart LR
 生成物を毎回作り直せることが前提なので、API 変更は OpenAPI と handler 実装にだけ加える。
 この境界により、schema と router の手編集による食い違いを防ぐ。
 
-## 6. transport と session
+## 6. RocketPack 型の生成
 
-### 6.1 接続とフレーム化
+### 6.1 rpf を型定義の正とする
+
+RocketPack で符号化する型は `.rpf` ファイルで定義し、Rust の型宣言と `RocketPackStruct` 実装を生成する。
+生成には core-rs の [rocketpack-compiler](../daemon/refs/core-rs/entrypoints/rocketpack-compiler) を使い、Axus はこれを外部ツールとして扱う。
+compiler の内部設計は §2.1 のとおり本書の対象外であり、本章は Axus から見た入出力と規約だけを定める。
+
+```mermaid
+flowchart LR
+    Rpf[rpf ファイル]
+    Conf[rocketpack.yaml]
+    Compiler[rocketpack-compiler]
+    Generated[生成された Rust module]
+    Engine[engine の実装]
+
+    Rpf --> Compiler
+    Conf --> Compiler
+    Compiler --> Generated
+    Generated --> Engine
+```
+
+型と field 番号の変更は rpf にだけ加え、生成物にも手書き実装にも加えない。
+定義を rpf 1 箇所に集めることで、encode 側と decode 側の field 番号の対応を人手で保つ必要がなくなる。
+
+### 6.2 生成の入力と出力
+
+compiler は指定した directory の `rocketpack.yaml` を読み、`sources` と `generators` に従って生成する。
+`sources` は `base_dir` と `includes`、`excludes` で対象の rpf を集める。
+`generators` は plugin ごとに `targets` を持ち、`pattern` に一致した rpf を `dir` 配下へ書き出す。
+出力は rpf 1 本につき Rust ファイル 1 本であり、ファイル名は rpf の stem を引き継ぐ。
+
+`pattern` に一致しない rpf は生成対象から外れるため、rpf を追加したときは target の追加も必要になる。
+同じ rpf を複数の generator へ渡せるので、言語ごとの出力先を 1 つの設定で管理できる。
+
+`rocketpack.yaml` を置いた directory が生成の起点であり、`base_dir` と `dir` はそこからの相対 path として解決する。
+設定 key の一覧と各 generator が解釈する option は、compiler のコードと [rocketpack-compiled-example](../daemon/refs/core-rs/entrypoints/rocketpack-compiled-example) が正である。
+
+### 6.3 rpf が表現するもの
+
+rpf は version、package、use、struct、enum、type alias、const を持つ。
+package は生成 Rust の入れ子 module になり、use は生成 Rust の use として写す。
+struct の field と enum の variant は `@N` の番号を持ち、この N が wire 上の field 番号である。
+`Option<T>` の field は値が `None` のとき map から省き、要素数もそれに合わせて数える。
+未知の番号を受け取った側は、その field を読み飛ばして残りの復号を続ける。
+
+**rpf から外部型として参照する Rust 型は、`RocketPackStruct` を実装していなければならない。**
+rpf 内で定義も alias もされていない名前は外部型として解決し、生成コードはその型の `RocketPackStruct` 実装を呼ぶ。
+実装がない型を参照した場合、誤りは生成時ではなく Rust の compile 時に現れる。
+
+### 6.4 手書き実装からの移行
+
+移行の不変条件は wire format を変えないことである。
+手書き実装が使っている field 番号をそのまま `@N` へ写し、番号の詰め直しや採番規則の統一を同時に行わない。
+`Option` の省略規則、map の要素数の数え方、未知 field の読み飛ばしは生成コードと手書き実装で一致するため、移行で注意すべきなのは field 番号の写し間違いと外部型の符号化方法の 2 点である。
+
+移行の単位は rpf ファイルとし、1 つの型の宣言と codec を手書きと生成物に分けない。
+分けると、その型の正がどちらにあるかを読む側が判断できなくなる。
+
+## 7. transport と session
+
+### 7.1 接続とフレーム化
 
 [connection](../daemon/modules/engine/src/base/connection.rs) は、TCP の受理と発信を trait の背後に置く。
 発信側は直接 TCP と SOCKS5 proxy を同じ境界で扱い、受理側は必要に応じて UPnP の port mapping を扱う。
@@ -190,7 +250,7 @@ flowchart LR
 RocketPack の encode と decode は [framed.rs](../daemon/modules/engine/src/base/connection/stream/framed.rs) の拡張を通す。
 これにより session と negotiator は、TCP の partial read やメッセージ境界を扱わずに済む。
 
-### 6.2 session の確立
+### 7.2 session の確立
 
 発信側と受理側は、version、challenge、signature、用途の順に合意する。
 
@@ -221,7 +281,7 @@ sequenceDiagram
 用途の確定を認証の後に置くことで、未認証の接続を NodeFinder や FileExchanger のキューに入れない。
 version 交渉は、双方が共通して対応する手順だけを選ばなければならない。
 
-### 6.3 用途と停止
+### 7.3 用途と停止
 
 1 本の Session は NodeFinder または FileExchanger のどちらか一方に割り当てる。
 用途ごとの受理キューと接続上限を分けることで、一方の負荷が他方の接続枠を使い切ることを防ぐ。
@@ -230,9 +290,9 @@ version 交渉は、双方が共通して対応する手順だけを選ばなけ
 [Shutdown](../daemon/modules/engine/src/base/runtime/shutdown.rs) は、所有する下位 component を順に停止するための共通契約である。
 worker は cancellation token または join handle を通じて停止し、所有者の寿命を越えて残らない。
 
-## 7. NodeFinder
+## 8. NodeFinder
 
-### 7.1 責務
+### 8.1 責務
 
 [NodeFinder](../daemon/modules/engine/src/core/negotiator/node/node_finder.rs) は、既知ノードの交換と、AssetKey を提供または要求するノードの所在情報を扱う。
 NodeFinder はアセットの内容を解釈せず、AssetKey と NodeProfile の対応だけを返す。
@@ -241,7 +301,7 @@ FileExchanger はこの境界を使うため、ノード探索の message とフ
 [NodeProfileFetcher](../daemon/modules/engine/src/core/negotiator/node/node_profile_fetcher.rs) は bootstrap 用の NodeProfile 群を外部から取得する。
 URI 変換の詳細と checksum は [converter/uri.rs](../daemon/modules/engine/src/model/converter/uri.rs) が正である。
 
-### 7.2 情報の配布
+### 8.2 情報の配布
 
 NodeFinder は要求、回答、自発的な広告を分けて伝播させる。
 
@@ -267,7 +327,7 @@ flowchart LR
 要求と広告を XOR 距離の近いノードへ寄せる一方、回答は要求元へ戻す。
 受信情報には寿命と件数上限を設け、古い所在情報と無制限な中継を残さない。
 
-### 7.3 判断と通信の分離
+### 8.3 判断と通信の分離
 
 [TaskComputer](../daemon/modules/engine/src/core/negotiator/node/task_computer.rs) は、全 session の受信状態と上位 component の要求を見て、次に送る DataMessage を計算する。
 [TaskCommunicator](../daemon/modules/engine/src/core/negotiator/node/task_communicator.rs) は、session ごとの handshake と送受信だけを担当する。
@@ -276,7 +336,7 @@ flowchart LR
 FileExchanger から必要な AssetKey を受け取る境界には [FnHub](../daemon/modules/engine/src/base/sync/fn_hub.rs) を使う。
 発火側と登録側を分けることで、NodeFinder は FileExchanger の具象型を参照しない。
 
-### 7.4 距離と永続化
+### 8.4 距離と永続化
 
 [Kadex](../daemon/modules/engine/src/core/negotiator/node/kadx.rs) は AssetKey の hash と NodeProfile の ID の XOR 距離を比較し、近いノードを選ぶ。
 距離計算の byte order は protocol の相互運用性に関わるため、別実装を追加する場合はコード上の規則を外部仕様へ昇格させる。
@@ -284,9 +344,9 @@ FileExchanger から必要な AssetKey を受け取る境界には [FnHub](../da
 [NodeFinderRepo](../daemon/modules/engine/src/core/negotiator/node/node_finder_repo.rs) は既知ノードを URI 表現のまま SQLite に保存する。
 URI を opaque な値として保存することで形式追加のたびに table schema を変えずに済むが、address 単位の SQL 検索は行えない。
 
-## 8. ファイルの公開と購読
+## 9. ファイルの公開と購読
 
-### 8.1 責務の分割
+### 9.1 責務の分割
 
 [FilePublisher](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher.rs) はローカルファイルを block と Merkle layer に変換し、公開可能な root hash を確定する。
 [FileSubscriber](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber.rs) は root hash から必要な block を管理し、揃った layer を上位から順に復号する。
@@ -295,7 +355,7 @@ URI を opaque な値として保存することで形式追加のたびに tabl
 符号化、転送、復号を分けることで、local storage の処理を network session の寿命から独立させる。
 publisher と subscriber は公開用と購読用の状態を共有しない。
 
-### 8.2 Merkle 構造
+### 9.2 Merkle 構造
 
 ファイル本体を rank 0 の固定長 block に分け、各 block の hash 列を上位の MerkleLayer として再帰的に block 化する。
 
@@ -321,7 +381,7 @@ root hash から下位 block の hash を段階的に得られるため、受信
 MerkleLayer の rank は encoder と decoder が同じ意味で解釈しなければならない。
 wire format と field 番号は [merkle_layer.rs](../daemon/modules/engine/src/core/negotiator/file/model/merkle_layer.rs) が正である。
 
-### 8.3 状態遷移
+### 9.3 状態遷移
 
 公開側は root hash の確定前後を uncommitted と committed に分ける。
 
@@ -351,9 +411,9 @@ stateDiagram-v2
 ```
 
 復号中に得た次の rank の hash 群が、次の Downloading の取得対象になる。
-外部 API は内部状態名をそのまま公開せず、§12.2 の長時間操作の表現に従って安定した契約へ変換する。
+外部 API は内部状態名をそのまま公開せず、§13.2 の長時間操作の表現に従って安定した契約へ変換する。
 
-### 8.4 接続相手と block の検証
+### 9.4 接続相手と block の検証
 
 公開側は自分が提供する AssetKey を要求するノードへ接続し、購読側は目的の AssetKey を提供するノードへ接続する。
 相手の探索は NodeFinder に委ね、FileExchanger は探索 algorithm を持たない。
@@ -362,9 +422,9 @@ stateDiagram-v2
 block 交換 protocol は、要求した hash、受信した hash、保存した block の対応を追跡しなければならない。
 汚染 block を永続化しないため、内容 hash の検証は commit より前に行う。
 
-## 9. 永続化
+## 10. 永続化
 
-### 9.1 metadata と block の分離
+### 10.1 metadata と block の分離
 
 | 種別     | 実体                              | 保存するもの                          |
 | -------- | --------------------------------- | ------------------------------------- |
@@ -374,7 +434,7 @@ block 交換 protocol は、要求した hash、受信した hash、保存した
 metadata は条件検索と状態遷移を必要とするため SQLite に置く。
 block は hash key による読み書きが中心であり、大きな byte 列を metadata query から分離するため RocksDB に置く。
 
-### 9.2 `state_dir` の構造
+### 10.2 `state_dir` の構造
 
 永続状態は component ごとに directory を分ける。
 
@@ -392,7 +452,7 @@ block は hash key による読み書きが中心であり、大きな byte 列�
 publisher と subscriber の保存領域を分けることで、一方の再構築や削除が他方の状態を直接壊さない。
 directory 名の追加や移行が必要な場合は migration と rollback の単位を明示する。
 
-### 9.3 論理 key と block 実体
+### 10.3 論理 key と block 実体
 
 [KeyValueRocksdbStorage](../daemon/modules/engine/src/base/storage/key_value_rocksdb_storage.rs) は、論理 key から内部 ID を引く `names` と、内部 ID から実体を引く `blocks` および `metas` を分ける。
 公開処理の commit は論理 key を uncommitted から committed へ変更し、同じ block 実体を再利用する。
@@ -400,7 +460,7 @@ directory 名の追加や移行が必要な場合は migration と rollback の�
 **rename の原子性は、対象が同じ RocksDB transaction 内にあることを前提とする。**
 別 database または別 filesystem へまたがる移動を追加した場合、この前提は崩れ、copy と recovery protocol が必要になる。
 
-### 9.4 schema migration
+### 10.4 schema migration
 
 [publisher_repo.rs](../daemon/modules/engine/src/core/negotiator/file/file_publisher/publisher_repo.rs)、[subscriber_repo.rs](../daemon/modules/engine/src/core/negotiator/file/file_subscriber/subscriber_repo.rs)、[node_finder_repo.rs](../daemon/modules/engine/src/core/negotiator/node/node_finder_repo.rs) は、名前付きの MigrationRequest を順に適用する。
 適用済みの名前を持つ migration は再実行しない。
@@ -408,21 +468,21 @@ directory 名の追加や移行が必要な場合は migration と rollback の�
 配布済みの状態へ適用され得る migration は書き換えず、新しい名前の migration で前進させる。
 初回 release 前の migration を直接修正する場合でも、適用済み状態が存在しないことを確認し、その確認結果を変更記録に残す。
 
-## 10. セキュリティ境界
+## 11. セキュリティ境界
 
-### 10.1 保証の分担
+### 11.1 保証の分担
 
 | 機構                           | 保証するもの                            | 保証しないもの                                 |
 | ------------------------------ | --------------------------------------- | ---------------------------------------------- |
 | session の challenge signature | 相手が応答に使った秘密鍵を所持すること  | DHT 上の NodeProfile.id との結合、相手への信頼 |
 | FramedStream                   | message 境界                            | 通信内容の機密性と改竄検出                     |
 | Merkle hash                    | 期待する hash に対する block 内容の一致 | 提供者の信頼性、検索結果の正当性               |
-| Web of Trust                   | §12.2 で決める信頼 policy               | transport の暗号化と block の内容検証          |
+| Web of Trust                   | §13.2 で決める信頼 policy               | transport の暗号化と block の内容検証          |
 
 認証、暗号化、内容 hash、信頼評価は別の保証であり、どれか 1 つで他を代替しない。
 特に session 認証が成功しても、相手の NodeProfile と公開内容を信頼できるとは限らない。
 
-### 10.2 脅威モデル
+### 11.2 脅威モデル
 
 NodeProfile.id を低コストで選べる場合、攻撃者は AssetKey に近い ID を集める Sybil 攻撃と Eclipse 攻撃を行える。
 既知ノードと伝播情報の件数上限は資源消費を抑えるが、攻撃者の情報だけが残ることは防がない。
@@ -431,9 +491,9 @@ Web of Trust はこの信頼選別を担うが、transport の盗聴と改竄に
 NodeFinder の中継は情報を増幅し得るため、TTL、件数、接続数、message size の上限を protocol の入力境界で強制する。
 FileExchanger は受信 block を hash 検証し、Profile 交換は署名と version 検証を通す。
 
-## 11. Profile と memo
+## 12. Profile と memo
 
-### 11.1 Profile が参照するデータ
+### 12.1 Profile が参照するデータ
 
 Profile は投稿本文や添付 byte 列を直接埋め込まず、公開済み File の FileRef を保持する。
 投稿群をまとめた File と、利用者が個別に公開した File は、どちらも先に FilePublisher へ渡して root hash を得る。
@@ -442,7 +502,7 @@ Profile は投稿本文や添付 byte 列を直接埋め込まず、公開済み
 この構造により、大きなデータの配布と Profile の更新を同じ protocol に重ねずに済む。
 Profile の真正性を検証しても、参照先 File の block hash 検証は省略しない。
 
-### 11.2 層ごとの責務
+### 12.2 層ごとの責務
 
 | 層                             | 責務                                                   | 知らないもの         |
 | ------------------------------ | ------------------------------------------------------ | -------------------- |
@@ -453,9 +513,9 @@ Profile の真正性を検証しても、参照先 File の block hash 検証は
 下位層は Profile を opaque な payload として扱い、上位層だけが FileRef の意味を解釈する。
 この境界により、掲示板や timeline のデータモデルを変えても、memo の探索と配布を作り直さずに済む。
 
-## 12. 設計判断
+## 13. 設計判断
 
-### 12.1 決定済み
+### 13.1 決定済み
 
 #### OpenAPI を REST 契約の正とする
 
@@ -467,6 +527,19 @@ schema、router、client が別々の定義を持つ状態を避け、変更点�
 
 **却下案**
 生成された interface の直接編集は、再生成で失われ、OpenAPI と実装を食い違わせるため採用しない。
+
+#### RocketPack 型を rpf から生成する
+
+**決定**
+RocketPack で符号化する型は rpf を正とし、Rust の型宣言と `RocketPackStruct` 実装を生成する。
+生成物は手で編集せず、型と field 番号の変更は rpf にだけ加える。
+
+**理由**
+手書きでは pack と unpack が同じ field 番号を別々の箇所で扱い、対応のずれを型で検出できないためである。
+定義を 1 箇所に集めることで、Rust 以外の言語向けの生成先を後から追加する余地も残る。
+
+**却下案**
+手書きの `RocketPackStruct` 実装を続ける案は、既存コードに採用の痕跡があるが、型の正が実装の中に散るため採用しない。
 
 #### 1 Session を 1 用途に割り当てる
 
@@ -501,7 +574,7 @@ MemoExchanger は Profile の意味を解釈せず、探索、交換、配布だ
 **理由**
 内容配布を既存の File protocol に集約し、Profile と掲示板の model を transport から分離するためである。
 
-### 12.2 保留
+### 13.2 保留
 
 #### NodeProfile.id と署名鍵の結合
 
@@ -585,6 +658,23 @@ MerkleLayer の rank が、その layer を格納する block の rank と、lay
 **決める条件**
 [ISSUES.md](./ISSUES.md) の I-4 を修正する前に決め、選んだ意味を encode と decode の contract test で固定する。
 
+#### rpf から参照する core-rs 型の扱い
+
+**現状**
+`OmniHash` は `RocketPackStruct` を実装しており、手書き実装も `write_struct` で符号化しているため、rpf からは外部型としてそのまま参照できる。
+`OmniAddr` は実装を持たず、手書きの `NodeProfile` は string として符号化している。
+
+候補は次の 2 つである。
+
+1. core-rs 側に `RocketPackStruct` を実装して外部型として参照すると、型と符号化を 1 箇所に置けるが、core-rs の型の wire format を Axus の都合で決めることになる。
+2. rpf では string や bytes などの組み込み型で表すと core-rs を変更せずに済むが、Rust 型との変換が Axus 側に手書きで残る。
+
+**なぜ今決めないか**
+現在の wire format を保つ実装はどちらの案でも書けるため、選択は変換を core-rs と Axus のどちらに置くかの問題に留まるためである。
+
+**決める条件**
+`OmniAddr` のように `RocketPackStruct` を持たない core-rs 型を含む型を、最初に rpf へ移す前に決める。
+
 #### Web of Trust の単位と伝播
 
 **現状**
@@ -633,9 +723,9 @@ FilePublisher と FileSubscriber の public operation が daemon 層に接続さ
 **決める条件**
 公開開始、購読開始、進捗取得の endpoint を `openapi.yaml` に追加する前に決める。
 
-## 13. 現状と残作業
+## 14. 現状と残作業
 
-### 13.1 現状
+### 14.1 現状
 
 | 領域               | コードで確認した現状                                                                                                                         |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -648,21 +738,24 @@ FilePublisher と FileSubscriber の public operation が daemon 層に接続さ
 | FileExchanger      | 接続と受理の task はあるが、block 要求と応答の message および送受信 loop がない                                                              |
 | Profile と memo    | FileRef 型はあるが、memo と MemoRef の module は空であり、Profile 型と上位サービス層はない                                                   |
 | 永続化             | NodeFinder、publisher、subscriber の repo と block storage があるが、ファイル経路には既知の schema 不具合がある                              |
+| RocketPack 型      | engine の型は手書きの `RocketPackStruct` 実装であり、Axus に rpf と `rocketpack.yaml` はない                                                 |
+| rpf の生成器       | compiler の rust generator だけが Rust を出力し、csharp と swift は log を残して生成を飛ばす                                                 |
 
 `todo!()` の現物は `rg 'todo!\(' daemon --glob '*.rs' --glob '!target/**'` で確認できる。
 空の module や結線されていない component は、この検索だけでは検出できない。
 
-### 13.2 ロードマップ
+### 14.2 ロードマップ
 
 次の順序は暫定であり、守る必要があるのは表中の依存関係だけである。
 
 | 番号 | 内容                                                                                 | 前提とする依存                                            |
 | ---- | ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| 1    | HTTP と P2P の設定を分離し、DaemonState が AxusService を所有して停止まで管理する    | §12.2 の secure channel は後から決められる                |
+| 1    | HTTP と P2P の設定を分離し、DaemonState が AxusService を所有して停止まで管理する    | §13.2 の secure channel は後から決められる                |
 | 2    | session と NodeFinder を daemon の起動経路から結合試験する                           | 1、関連する既知の不具合の解消                             |
 | 3    | publisher と subscriber の schema を修正し、初期化、符号化、復号を実データで検証する | 適用済み migration の有無の確認                           |
 | 4    | FileExchanger の block 交換 protocol と hash 検証を定義して実装する                  | 2、3、secure channel の判断                               |
-| 5    | 公開、購読、進捗、cancel の REST API を定義する                                      | 4、§12.2 の長時間操作の判断                               |
-| 6    | identity、Web of Trust、Profile、memo を順に定義する                                 | §12.2 の identity と trust の判断、FileRef を解決できる 4 |
+| 5    | 公開、購読、進捗、cancel の REST API を定義する                                      | 4、§13.2 の長時間操作の判断                               |
+| 6    | identity、Web of Trust、Profile、memo を順に定義する                                 | §13.2 の identity と trust の判断、FileRef を解決できる 4 |
+| 7    | 手書きの RocketPack 型を rpf へ移し、生成物へ置き換える                              | §13.2 の core-rs 型の扱いの判断                           |
 
 確認済みの不具合と修正方針は [ISSUES.md](./ISSUES.md) を参照する。

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,7 +1,7 @@
 # Axus 既知の不具合
 
 本書は、コードを読んで確認した明確な不具合を扱う。
-設計上の未決事項は扱わず、[DESIGN.md §12.2](./DESIGN.md#122-保留) に置く。
+設計上の未決事項は扱わず、[DESIGN.md §13.2](./DESIGN.md#132-保留) に置く。
 
 ## この文書の使い方
 
@@ -103,7 +103,7 @@ I-1 により FileExchanger が daemon から構築されないため、現在�
 ### 対応方針
 
 対象 table と model に合わせて索引、primary key、列名を修正する。
-既存 MigrationRequest を直接修正できるかは、[DESIGN.md §9.4](./DESIGN.md#94-schema-migration) に従って判断する。
+既存 MigrationRequest を直接修正できるかは、[DESIGN.md §10.4](./DESIGN.md#104-schema-migration) に従って判断する。
 適用済み環境が存在しないことを確認できた場合に限り、既存 MigrationRequest を直接修正する。
 適用済み環境が存在する場合、または存在しないことを確認できない場合は、新しい MigrationRequest を追加する。
 修正後は publisher と subscriber の初期化 test を追加する。
@@ -189,7 +189,7 @@ encoder と decoder は異なる意味で実装されている。
 
 ### 対応方針
 
-[DESIGN.md §12.2](./DESIGN.md#merklelayerrank-の意味) で rank の意味を決める。
+[DESIGN.md §13.2](./DESIGN.md#merklelayerrank-の意味) で rank の意味を決める。
 決定した意味に合わせて encoder と decoder を同時に修正する。
 encode から decode までの round-trip test で契約を固定する。
 
@@ -276,7 +276,7 @@ V2 以降を追加すると、接続成立後に message の解釈が食い違�
 
 3 箇所の `|` を `&` に変更する。
 積集合が空の場合は、対応 version がないことを示す error を返す。
-複数の共通 version から 1 つを選ぶ規則は [DESIGN.md §12.2](./DESIGN.md#session-の-version-選択) で決める。
+複数の共通 version から 1 つを選ぶ規則は [DESIGN.md §13.2](./DESIGN.md#session-の-version-選択) で決める。
 共通 version がない場合と複数ある場合の test を追加する。
 
 <a id="i-7"></a>
@@ -307,7 +307,7 @@ session 層の相互認証で node ごとの鍵を識別できない。
 
 ### 対応方針
 
-[DESIGN.md §12.2](./DESIGN.md#nodeprofileid-と署名鍵の結合) で node identity と署名鍵の関係を決める。
+[DESIGN.md §13.2](./DESIGN.md#nodeprofileid-と署名鍵の結合) で node identity と署名鍵の関係を決める。
 決定した identity に基づいて signer の識別子と永続化方法を実装する。
 node ごとに異なる鍵が生成または復元されることを test する。
 
@@ -425,10 +425,10 @@ I-8 の設定ファイル名変更も同じ test で検証する。
 
 | 項目                                        | 参照                                                         |
 | ------------------------------------------- | ------------------------------------------------------------ |
-| session の secure channel がない            | [DESIGN.md §12.2](./DESIGN.md#session-の-secure-channel)     |
-| FileExchanger の block 交換 protocol がない | [DESIGN.md §8.4](./DESIGN.md#84-接続相手と-block-の検証)     |
-| 購読開始の入口がない                        | [DESIGN.md §13.1](./DESIGN.md#131-現状)                      |
-| NodeFinder の能動探索がない                 | [DESIGN.md §12.2](./DESIGN.md#nodefinder-の能動探索と冗長度) |
-| Web of Trust が未設計である                 | [DESIGN.md §12.2](./DESIGN.md#web-of-trust-の単位と伝播)     |
-| Profile と memo が未実装である              | [DESIGN.md §11.2](./DESIGN.md#112-層ごとの責務)              |
-| 長時間 REST 操作の表現が未決である          | [DESIGN.md §12.2](./DESIGN.md#長時間-rest-操作の表現)        |
+| session の secure channel がない            | [DESIGN.md §13.2](./DESIGN.md#session-の-secure-channel)     |
+| FileExchanger の block 交換 protocol がない | [DESIGN.md §9.4](./DESIGN.md#94-接続相手と-block-の検証)     |
+| 購読開始の入口がない                        | [DESIGN.md §14.1](./DESIGN.md#141-現状)                      |
+| NodeFinder の能動探索がない                 | [DESIGN.md §13.2](./DESIGN.md#nodefinder-の能動探索と冗長度) |
+| Web of Trust が未設計である                 | [DESIGN.md §13.2](./DESIGN.md#web-of-trust-の単位と伝播)     |
+| Profile と memo が未実装である              | [DESIGN.md §12.2](./DESIGN.md#122-層ごとの責務)              |
+| 長時間 REST 操作の表現が未決である          | [DESIGN.md §13.2](./DESIGN.md#長時間-rest-操作の表現)        |


### PR DESCRIPTION
## 概要

RocketPack 型の生成方針を設計書に追加します。

## 変更内容

`docs/DESIGN.md`:
- `rpf` を型定義の正とする章を追加し、以降の章番号を繰り下げ
- 設計判断に `rpf` からの生成と core-rs 型の扱いを追加
- 現状と残作業に `rpf` の生成状況と移行手順を追加

`docs/ISSUES.md`:
- 章番号の変更に合わせて `DESIGN.md` への参照を更新