### PR TITLE
fix: migrate daemon config to axus.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ sudo apt-get install -y libclang-dev
 ```
 This package is required for RocksDB.
 
+### Daemon Configuration
+
+The daemon selects its configuration directory from `AXUS_DAEMON_CONFIG_DIR`, `~/.config/axus`, then `.config/axus`.
+The selected directory must contain [axus.toml](./daemon/config/axus.toml).
+
+Run the repository's development configuration with:
+
+```sh
+cargo run --manifest-path daemon/Cargo.toml -p omnius-axus-daemon -- start --config-dir daemon/config
+```
+
 ## Docs
 
 - [DESIGN.md](./docs/DESIGN.md)

--- a/daemon/.gitignore
+++ b/daemon/.gitignore
@@ -3,6 +3,9 @@
 /bin
 /state
 
+config/*
+!config/axus.toml
+
 # Visual Studio Code
 .vscode/*
 !.vscode/tasks.json

--- a/daemon/axus-config.toml
+++ b/daemon/axus-config.toml
@@ -1,2 +1,0 @@
-listen_addr = "127.0.0.1:5050"
-state_dir = "./state"

--- a/daemon/config/axus.toml
+++ b/daemon/config/axus.toml
@@ -1,0 +1,7 @@
+[core]
+state_dir = "./state"
+listen_addr = "127.0.0.1:5050"
+
+[logging]
+level = "info"
+json = false

--- a/daemon/entrypoints/daemon/src/config.rs
+++ b/daemon/entrypoints/daemon/src/config.rs
@@ -60,7 +60,7 @@ impl DaemonConfig {
     }
 
     async fn load_toml(dir: &Path) -> Result<DaemonConfigToml> {
-        let toml_path = dir.join("pxna.toml");
+        let toml_path = dir.join("axus.toml");
         let toml = tokio::fs::read_to_string(toml_path).await?;
         Ok(toml::from_str(&toml)?)
     }
@@ -68,15 +68,12 @@ impl DaemonConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write as _;
-
     use testresult::TestResult;
 
     use super::*;
 
-    #[ignore]
     #[tokio::test]
-    async fn secret_reader_test() -> TestResult {
+    async fn load_config_test() -> TestResult {
         let toml = r#"
             [core]
             state_dir = "./state"
@@ -88,13 +85,26 @@ mod tests {
         "#;
 
         let tempdir = tempfile::tempdir()?;
-        let config_path = tempdir.path().join("pxna.toml");
-        std::fs::File::create(&config_path)?.write_all(toml.as_bytes())?;
+        std::fs::write(tempdir.path().join("axus.toml"), toml)?;
 
         let conf = DaemonConfig::load(tempdir.path()).await?;
 
-        assert_eq!(conf.core.listen_addr, "0.0.0.0:6050");
+        assert_eq!(conf.core.listen_addr, "0.0.0.0:6051");
         assert_eq!(conf.core.state_dir, tempdir.path().join("./state"));
+        assert_eq!(conf.logging.level, "info");
+        assert!(!conf.logging.json);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_repository_sample_test() -> TestResult {
+        let config_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../config");
+
+        let conf = DaemonConfig::load(&config_dir).await?;
+
+        assert_eq!(conf.core.listen_addr, "127.0.0.1:5050");
+        assert_eq!(conf.core.state_dir, config_dir.join("./state"));
         assert_eq!(conf.logging.level, "info");
         assert!(!conf.logging.json);
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -23,13 +23,9 @@
 | [I-5](#i-5)   | FileExchanger 要求で受理 task が panic し、受信が停止する     | 高     | 未起票 |
 | [I-6](#i-6)   | version 交渉が積集合ではなく和集合になっている                | 中     | 未起票 |
 | [I-7](#i-7)   | 署名鍵の識別子が `"TODO"` 固定である                          | 中     | 未起票 |
-| [I-8](#i-8)   | 設定ファイル名が `pxna.toml` のままである                     | 低     | 未起票 |
-| [I-9](#i-9)   | `axus-config.toml` が現在の parser と整合しない               | 低     | 未起票 |
-| [I-10](#i-10) | 設定 test が期待値不一致のまま無効化されている                | 低     | 未起票 |
 
 I-1 は P2P component を daemon から実行するための前提である。
 I-2、I-3、I-4 はファイル公開と購読の同じ経路にあるため、結線前にまとめて修正する。
-I-8、I-9、I-10 は設定ファイルの命名、sample、test に関する同じ経路にあるため、同時に修正する。
 
 <a id="i-1"></a>
 ## I-1. `DaemonState` が `AxusService` を生成せず、P2P 層が起動しない
@@ -310,113 +306,6 @@ session 層の相互認証で node ごとの鍵を識別できない。
 [DESIGN.md §13.2](./DESIGN.md#nodeprofileid-と署名鍵の結合) で node identity と署名鍵の関係を決める。
 決定した identity に基づいて signer の識別子と永続化方法を実装する。
 node ごとに異なる鍵が生成または復元されることを test する。
-
-<a id="i-8"></a>
-## I-8. 設定ファイル名が `pxna.toml` のままである
-
-**深刻度: 低**
-
-### 症状
-
-Axus daemon は `axus.toml` ではなく `pxna.toml` という名前の設定ファイルを要求する。
-利用者が Axus の名前から設定ファイルを推測できない。
-
-### 該当箇所
-
-[config.rs:63](../daemon/entrypoints/daemon/src/config.rs#L63) が固定ファイル名を指定している。
-
-```rust
-let toml_path = dir.join("pxna.toml");
-```
-
-[config.rs:91](../daemon/entrypoints/daemon/src/config.rs#L91) の test fixture も同じ名前を使う。
-
-### 原因
-
-設定ファイルの固定名が `pxna.toml` のまま残っている。
-この名前を採用した理由はコードに記録されていない。
-
-### 影響
-
-利用者は Axus と異なる名前の設定ファイルを配置する必要がある。
-README に固定名の説明がないため、設定方法を発見しにくい。
-
-### 対応方針
-
-固定名を `axus.toml` に変更する。
-test fixture と README の設定手順も同じ名前へ更新する。
-I-9 と I-10 を同時に修正する。
-
-<a id="i-9"></a>
-## I-9. `axus-config.toml` が現在の parser と整合しない
-
-**深刻度: 低**（通常の設定読込経路では未顕在）
-
-### 症状
-
-repository にある `axus-config.toml` を現在の parser へ渡すと parse error になる。
-CLI はこのファイルを自動では読み込まない。
-
-### 該当箇所
-
-[axus-config.toml:1](../daemon/axus-config.toml#L1) は section を持たない。
-
-```toml
-listen_addr = "127.0.0.1:5050"
-state_dir = "./state"
-```
-
-[config.rs:8](../daemon/entrypoints/daemon/src/config.rs#L8) の `DaemonConfigToml` は `core` と `logging` を要求する。
-[config.rs:63](../daemon/entrypoints/daemon/src/config.rs#L63) は config directory 配下の固定名ファイルだけを読む。
-
-### 原因
-
-repository 直下の設定例が古い schema と配置方法のまま残っている。
-
-### 影響
-
-通常の設定読込経路ではこのファイルを読まないため、daemon の動作には影響しない。
-repository を読んだ利用者には有効な設定例に見えるため、設定方法を誤解させる。
-
-### 対応方針
-
-現在の schema に合わせた `axus.toml.example` へ置き換える。
-README に sample を config directory へコピーする手順を記載する。
-I-8 で変更する固定名と一致させる。
-
-<a id="i-10"></a>
-## I-10. 設定 test が期待値不一致のまま無効化されている
-
-**深刻度: 低**（`#[ignore]` により現時点では未顕在）
-
-### 症状
-
-通常の test 実行では設定読込 test が実行されない。
-ignore を外して実行すると、fixture と期待値の不一致により失敗する。
-
-### 該当箇所
-
-[config.rs:77](../daemon/entrypoints/daemon/src/config.rs#L77) が test に `#[ignore]` を付けている。
-[config.rs:83](../daemon/entrypoints/daemon/src/config.rs#L83) は `listen_addr` に `0.0.0.0:6051` を設定する。
-[config.rs:96](../daemon/entrypoints/daemon/src/config.rs#L96) は `0.0.0.0:6050` を期待する。
-[config.rs:79](../daemon/entrypoints/daemon/src/config.rs#L79) の test 名は内容と一致しない。
-
-### 原因
-
-期待値と fixture の不一致が修正されないまま、test 全体が ignore されている。
-test 名も以前の用途を示す `secret_reader_test` のままである。
-
-### 影響
-
-CI は設定読込の regression を検出できない。
-現在の test が失敗することも CI から見えない。
-
-### 対応方針
-
-期待値を fixture に合わせる。
-test 名を `load_config_test` へ変更する。
-`#[ignore]` を外して CI で常時実行する。
-I-8 の設定ファイル名変更も同じ test で検証する。
 
 ## ここに含めていないもの
 


### PR DESCRIPTION
## 背景

Axus daemon が `pxna.toml` を固定名として要求し、repository の設定例は current parser が要求する schema と一致していなかった。
設定読込 test も無効化されていたため、sample と loader の回帰を通常の test で検出できなかった。

## 概要

設定ファイル名を `axus.toml` に統一し、current schema の sample、loader の contract test、README を同じ設定契約へ揃えた。

## 変更内容

### 設定契約

loader は選択した設定 directory の `axus.toml` だけを読む。
追跡する sample は `core` と `logging` を明示し、生成される state と lock は引き続き追跡しない。

### 回帰検証と案内

temporary directory と repository sample の両方を loader 経由で読む test を常時実行する。
README は設定 directory の選択順と開発用 `--config-dir daemon/config` を案内する。
解決済みの I-8、I-9、I-10 は ISSUES から削除した。

## 影響範囲

既存の `pxna.toml` は読まれないため、利用者は設定ファイルを `axus.toml` へ移す必要がある。
設定 directory の選択順、state の相対解決、HTTP API と P2P transport の設定は変更しない。

## 検証

- [x] `env -u RUSTC_WRAPPER cargo test --manifest-path daemon/Cargo.toml -p omnius-axus-daemon config::tests`：2 passed。
- [x] `git check-ignore --no-index -q daemon/config/state && git check-ignore --no-index -q daemon/config/axus.lock && ! git check-ignore --no-index -q daemon/config/axus.toml`：sample と生成物の追跡規則を確認。
- [x] `cargo fmt --manifest-path daemon/Cargo.toml --all -- --check && git diff --check`：成功。
- [ ] GitHub Actions：PR 作成後に確認する。

## レビュー観点

- 固定名の互換 fallback を置かず、`axus.toml` への移行だけに限定した境界。
- repository sample を直接読む test が loader と schema の分岐を防げているか。