### PR TITLE
ci: run daemon tests through cargo make

### DIFF
--- a/.github/workflows/test-daemon-all.yml
+++ b/.github/workflows/test-daemon-all.yml
@@ -95,6 +95,13 @@ jobs:
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Setup cargo make
+        uses: davidB/rust-cargo-make@v1
+        with:
+          version: latest
 
       - name: Install cargo nextest
         uses: taiki-e/install-action@nextest
@@ -109,4 +116,4 @@ jobs:
             daemon -> target
 
       - name: Test
-        run: cargo nextest run --features "stable-test"
+        run: cargo make test

--- a/.github/workflows/test-daemon-slim.yml
+++ b/.github/workflows/test-daemon-slim.yml
@@ -89,6 +89,13 @@ jobs:
 
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Setup cargo make
+        uses: davidB/rust-cargo-make@v1
+        with:
+          version: latest
 
       - name: Install cargo nextest
         uses: taiki-e/install-action@nextest
@@ -103,4 +110,4 @@ jobs:
             daemon -> target
 
       - name: Test
-        run: cargo nextest run
+        run: cargo make test

--- a/daemon/Makefile.toml
+++ b/daemon/Makefile.toml
@@ -15,6 +15,7 @@ workspace = false
 dependencies = ["fmt-check", "clippy"]
 
 [tasks.test]
+workspace = false
 command = "cargo"
-args = ["test", "--all-features"]
+args = ["nextest", "run", "--all-features"]
 dependencies = ["lint"]


### PR DESCRIPTION
## 背景

local の `cargo make test` は lint を経由して `cargo test --all-features` を実行していた一方、CI は workflow ごとに直接 `cargo nextest run` を実行していた。
実行経路と feature set を一つの task に集約する。

## 概要

`cargo make test` を daemon workspace 一回の `cargo nextest run --all-features` へ変更し、両 daemon CI workflow の test job からこの task を呼ぶ。

## 変更内容

### Local test task

workspace 再帰を止めるため `workspace = false` を設定する。
これにより `daemon/refs/core-rs` の個別 Makefile を再帰実行せず、daemon workspace を一度だけ nextest で実行する。
lint dependency は維持する。

### CI

slim と all の test job に cargo-make と lint dependency 用の clippy/rustfmt を用意する。
直接の nextest command を `cargo make test` へ置き換える。

## 影響範囲

local と両 CI workflow の test は同じ `--all-features` の nextest 実行になる。
CI test job は lint も実行するため、format または clippy の失敗も test job で検出される。
production binary、設定、HTTP API は変更しない。

## 検証

- [x] `env -u RUSTC_WRAPPER cargo make test`：fmt、clippy、nextest が成功。62 passed、14 skipped。
- [x] `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/test-daemon-slim.yml .github/workflows/test-daemon-all.yml`：workflow YAML を parse。
- [x] `git diff --check`：成功。
- [ ] GitHub Actions：PR 作成後に確認する。

## レビュー観点

- `workspace = false` により nextest が daemon workspace を一度だけ実行すること。
- 両 workflow の test job が `cargo make test` の lint dependency を満たしていること。